### PR TITLE
add failing test for nature

### DIFF
--- a/tests/samples/nature.html
+++ b/tests/samples/nature.html
@@ -1,0 +1,2562 @@
+<!DOCTYPE html>\n
+<html lang="en" class="grade-c">
+   \n
+   <head>
+      \n
+      <title>A cross-sectional analysis of meteorological factors and SARS-CoV-2 transmission in 409 cities across 26 countries | Nature Communications</title>
+      \n    \n        \n    \n        \n        <script id="save-data-connection-testing">\n            function hasConnection() {\n                return navigator.connection || navigator.mozConnection || navigator.webkitConnection || navigator.msConnection;\n            }\n\n            function createLink(src) {\n                var preloadLink = document.createElement("link");\n                preloadLink.rel = "preload";\n                preloadLink.href = src;\n                preloadLink.as = "font";\n                preloadLink.type = "font/woff2";\n                preloadLink.crossOrigin = "";\n                document.head.insertBefore(preloadLink, document.head.firstChild);\n            }\n\n            var connectionDetail = {\n                saveDataEnabled: false,\n                slowConnection: false\n            };\n\n            var connection = hasConnection();\n            if (connection) {\n                connectionDetail.saveDataEnabled = connection.saveData;\n                if (/\\slow-2g|2g/.test(connection.effectiveType)) {\n                    connectionDetail.slowConnection = true;\n                }\n            }\n\n            if (!(connectionDetail.saveDataEnabled || connectionDetail.slowConnection)) {\n                createLink("/static/fonts/HardingText-Regular-Web.b167e675dc.woff2");\n            } else {\n                document.documentElement.classList.add(\'save-data\');\n            }\n        </script>\n    \n\n\n
+      <meta http-equiv="X-UA-Compatible" content="IE=edge">
+      \n
+      <meta name="applicable-device" content="pc,mobile">
+      \n
+      <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=5,user-scalable=yes">
+      \n\n\n    <script data-test="dataLayer">\n        dataLayer = [{"content":{"category":{"contentType":"article","legacy":{"webtrendsPrimaryArticleType":"research","webtrendsSubjectTerms":"climate-sciences;epidemiology;risk-factors;sars-cov-2","webtrendsContentCategory":null,"webtrendsContentCollection":null,"webtrendsContentGroup":"Nature Communications","webtrendsContentGroupType":null,"webtrendsContentSubGroup":"Article"}},"article":{"doi":"10.1038/s41467-021-25914-8"},"attributes":{"cms":null,"deliveryPlatform":"oscar","copyright":{"open":true,"legacy":{"webtrendsLicenceType":"http://creativecommons.org/licenses/by/4.0/"}}},"contentInfo":{"authors":["Francesco Sera","Ben Armstrong","Sam Abbott","Sophie Meakin","Kathleen O’Reilly","Rosa von Borries","Rochelle Schneider","Dominic Royé","Masahiro Hashizume","Mathilde Pascal","Aurelio Tobias","Ana Maria Vicedo-Cabrera","Wenbiao Hu","Shilu Tong","Eric Lavigne","Patricia Matus Correa","Xia Meng","Haidong Kan","Jan Kynčl","Aleš Urban","Hans Orru","Niilo R. I. Ryti","Jouni J. K. Jaakkola","Simon Cauchemez","Marco Dallavalle","Alexandra Schneider","Ariana Zeka","Yasushi Honda","Chris Fook Sheng Ng","Barrak Alahmad","Shilpa Rao","Francesco Di Ruscio","Gabriel Carrasco-Escobar","Xerxes Seposo","Iulian Horia Holobâcă","Ho Kim","Whanhee Lee","Carmen Íñiguez","Martina S. Ragettli","Alicia Aleman","Valentina Colistro","Michelle L. Bell","Antonella Zanobetti","Joel Schwartz","Tran Ngoc Dang","Noah Scovronick","Micheline de Sousa Zanotti Stagliorio Coélho","Magali Hurtado Diaz","Yuzhou Zhang","Timothy W. Russell","Mihaly Koltai","Adam J. Kucharski","Rosanna C. Barnard","Matthew Quaife","Christopher I. Jarvis","Jiayao Lei","James D. Munday","Yung-Wai Desmond Chan","Billy J. Quilty","Rosalind M. Eggo","Stefan Flasche","Anna M. Foss","Samuel Clifford","Damien C. Tully","W. John Edmunds","Petra Klepac","Oliver Brady","Fabienne Krauer","Simon R. Procter","Thibaut Jombart","Alicia Rosello","Alicia Showering","Sebastian Funk","Joel Hellewell","Fiona Yueqian Sun","Akira Endo","Jack Williams","Amy Gimma","Naomi R. Waterlow","Kiesha Prem","Nikos I. Bosse","Hamish P. Gibbs","Katherine E. Atkins","Carl A. B. Pearson","Yalda Jafari","C. Julian Villabona-Arenas","Mark Jit","Emily S. Nightingale","Nicholas G. Davies","Kevin van Zandvoort","Yang Liu","Frank G. Sandmann","William Waites","Kaja Abbas","Graham Medley","Gwenan M. Knight","Antonio Gasparrini","Rachel Lowe"],"publishedAt":1634083200,"publishedAtString":"2021-10-13","title":"A cross-sectional analysis of meteorological factors and SARS-CoV-2 transmission in 409 cities across 26 countries","legacy":null,"publishedAtTime":null,"documentType":"aplusplus"},"journal":{"pcode":"ncomms","title":"nature communications","volume":"12","issue":"1"},"authorization":{"status":true},"features":[{"name":"furtherReadingSection","present":false}],"collection":null},"page":{"category":{"pageType":"article"},"attributes":{"template":"mosaic","featureFlags":[{"name":"ab_test_highlight_supp_info","active":false},{"name":"nature-oa-paywall","active":true},{"name":"nature-onwards-journey","active":false}],"testGroup":null},"search":null},"privacy":{},"version":"1.0.0","product":null,"session":null,"user":null,"backHalfContent":true,"country":"US","hasBody":true,"uneditedManuscript":false,"twitterId":["o3xnx","o43y9","o3ef7"]}];\n    </script>\n\n\n<script>\n    (function(w, d) {\n        w.config = w.config || {};\n        w.config.mustardcut = false;\n\n        \n        if (w.matchMedia && w.matchMedia(\'only screen and (-webkit-min-device-pixel-ratio:0) and (min-color-index:0), (-ms-high-contrast: none), only all and (min--moz-device-pixel-ratio:0) and (min-resolution: 3e1dpcm)\').matches) {\n            w.config.mustardcut = true;\n            d.classList.add(\'js\');\n            d.classList.remove(\'grade-c\');\n        }\n    })(window, document.documentElement);\n</script>\n \n\n\n\n     \n        \n
+      <style>html{text-size-adjust:100%;box-sizing:border-box;font-family:sans-serif;font-size:62.5%;height:100%;line-height:1.15;overflow-y:scroll}body{background:#eee;color:#222;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;line-height:1.76;min-height:100%}article,aside,header,main,nav,section{display:block}h1{font-size:30px}a,sup{vertical-align:baseline}a{background-color:transparent;color:#069;text-decoration:underline}b{font-weight:bolder}sup{font-size:75%;line-height:0;position:relative;top:-.5em}img{border:0;height:auto;max-width:100%;vertical-align:middle}svg:not(:root){overflow:hidden}button,input,select{font-family:sans-serif;font-size:100%;line-height:1.15}select{margin:0}button,input{overflow:visible}button,select{text-transform:none}[type=submit],button{-webkit-appearance:button}[hidden]{display:none}button{border-radius:0;cursor:pointer;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif}h2{font-size:24px}h3{font-size:17px}h1{-webkit-font-smoothing:antialiased;font-family:Harding,Palatino,serif;font-size:3.2rem;font-weight:700;letter-spacing:-.0625rem;line-height:3.6rem}.c-card--major .c-card__title,.u-h2,h2{font-family:Harding,Palatino,serif;font-size:2.4rem;line-height:2.6rem}.c-card--major .c-card__title,.u-h2{letter-spacing:-.01875rem;margin-bottom:8px}h2,h3{letter-spacing:-.01875rem}.c-card--major .c-card__title,.c-card__title,.c-reading-companion__figure-title,.u-h2,.u-h3,.u-h4,h2,h3,h4,h5,h6{-webkit-font-smoothing:antialiased;font-weight:700}.c-card__title,.c-reading-companion__figure-title,.u-h3,.u-h4,h3,h4,h5,h6{line-height:2.2rem}.c-card__title,h3{font-family:Harding,Palatino,serif;font-size:2rem}.c-reading-companion__figure-title,.u-h3,.u-h4{letter-spacing:-.01875rem}.u-h3{font-family:Harding,Palatino,serif;font-size:2rem;margin-bottom:8px}.c-reading-companion__figure-title,.u-h4{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;font-size:1.8rem}.u-h4{margin-bottom:8px}body,button,div,form,h1,h2,h3,input{margin:0;padding:0}p{padding:0}nav ol,nav ul{list-style:none none}body{font-size:1.8em}p{margin:0 0 28px}ol,ul{margin-bottom:28px;margin-top:0}p:empty{display:none}.sans-serif{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif}.article-page{background:#fff}.c-article-header{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;margin-bottom:40px}.c-article-identifiers{color:#6f6f6f;display:flex;flex-wrap:wrap;font-size:1.6rem;line-height:1.3;list-style:none;margin:0 0 8px;padding:0}.c-article-identifiers__item{border-right:1px solid #6f6f6f;list-style:none;margin-right:8px;padding-right:8px}.c-article-identifiers__item:last-child{border-right:0;margin-right:0;padding-right:0}.c-article-identifiers__open{color:#b74616}.c-article-title{font-size:2.4rem;line-height:1.25;margin-bottom:16px}@media only screen and (min-width:768px){.c-article-title{font-size:3rem;line-height:1.2}}.c-article-author-list{font-size:1.6rem;list-style:none;margin-bottom:0;padding:0;width:100%}.c-article-author-list__item{margin-left:0}.c-article-author-list__item,.c-article-author-list li{display:inline;padding-right:0}.c-article-author-list__item svg,.c-reading-companion__figure-full-link svg{margin-left:4px}.c-article-author-list__show-less{margin-left:8px}.js .js-author-etal{display:none;visibility:hidden}@media only screen and (max-width:539px){.js .js-smaller-author-etal{display:none;visibility:hidden}}.c-article-info-details{font-size:1.6rem;margin-bottom:8px;margin-top:16px}.c-article-info-details__cite-as{border-left:1px solid #6f6f6f;margin-left:8px;padding-left:8px}.c-article-metrics-bar{display:flex;flex-wrap:wrap;font-size:1.6rem;line-height:1.3}.c-article-metrics-bar__wrapper{margin:0 0 16px}.c-article-metrics-bar__item{-webkit-box-align:baseline;align-items:baseline;border-right:1px solid #6f6f6f;margin-right:8px}.c-article-metrics-bar__item:last-child{border-right:0}.c-article-metrics-bar__count{font-weight:700;margin:0}.c-article-metrics-bar__label{color:#626262;font-style:normal;font-weight:400;margin:0 10px 0 5px}.c-article-metrics-bar__details{margin:0}.c-article-main-column{font-family:Harding,Palatino,serif;margin-right:8.6%;width:60.2%}@media only screen and (max-width:1023px){.c-article-main-column{margin-right:0;width:100%}}.c-article-section{clear:both}.c-article-associated-content__container .c-article-associated-content__title,.c-article-section__title{border-bottom:2px solid #d5d5d5;font-size:2rem;line-height:1.3;padding-bottom:8px}@media only screen and (min-width:768px){.c-article-associated-content__container .c-article-associated-content__title,.c-article-section__title{font-size:2.4rem;line-height:1.24}}.c-article-section__content{margin-bottom:40px;padding-top:8px}@media only screen and (max-width:1023px){.c-article-section__content{padding-left:0}}.c-article-authors-search{margin-bottom:24px;margin-top:0}.c-article-authors-search__item,.c-article-authors-search__title{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif}.c-article-authors-search__title{color:#626262;font-size:1.7rem;font-weight:700;margin:0;padding:0}.c-article-authors-search__item{font-size:1.6rem}.c-article-authors-search__text{margin:0}.c-article-share-box__no-sharelink-info{font-size:1.3rem;font-weight:700;margin-bottom:24px;padding-top:4px}.c-article-share-box__only-read-input{border:1px solid #d5d5d5;display:inline-block;font-size:1.4rem;font-weight:700;margin-bottom:8px;padding:8px 10px}.c-article-share-box__button--link-like{background-color:transparent;border:0;color:#069;cursor:pointer;font-size:1.4rem;margin-bottom:8px;margin-left:10px}.c-article-body{clear:both}.c-article-body a,.c-article-body p{overflow-wrap:break-word}.c-article-body a{word-break:break-word}.c-article-editorial-summary__container{border-bottom:1px solid #d5d5d5;clear:both;float:left;margin-bottom:16px;width:100%}.c-article-editorial-summary__container .c-article-editorial-summary__title{line-height:1.4;margin-bottom:16px}.c-article-editorial-summary__container .c-article-editorial-summary__article-title{font-size:1.4rem;line-height:1.4;margin-bottom:8px}.c-article-editorial-summary__container .c-article-editorial-summary__content{font-family:Harding,Palatino,serif;font-size:1.4rem}.c-article-editorial-summary__container .c-article-editorial-summary__content p:last-child{margin-bottom:0}.c-article-editorial-summary__container .c-article-editorial-summary__content--less{max-height:9.5rem;overflow:hidden}.c-article-editorial-summary__container .c-article-editorial-summary__button{background-color:#fff;border:0;color:#069;font-size:1.4rem;margin-bottom:16px}.c-article-editorial-summary__container .c-article-editorial-summary__button:focus,.c-article-editorial-summary__container .c-article-editorial-summary__button:hover{text-decoration:underline}.c-article-associated-content__container .c-article-associated-content__collection,.c-article-associated-content__container .c-article-associated-content__item{margin-bottom:24px;overflow:hidden}.c-article-associated-content__container .c-article-associated-content__collection-label{color:inherit;font-size:1.4rem;font-weight:700;line-height:1.4;margin-bottom:8px}.c-article-associated-content__container .c-article-associated-content__collection-title,.c-nature-box{line-height:1.3;margin-bottom:8px}@media only screen and (min-width:1024px){.c-pdf-button__container{display:none}}.c-context-bar{box-shadow:0 0 10px 0 rgba(51,51,51,.2);position:relative;width:100%}.c-context-bar__title,.c-header__menu--global .c-header__item svg{display:none}.c-article-extras{float:left;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;width:31.2%}@media only screen and (max-width:1023px){.c-article-extras{display:none}}.c-reading-companion{clear:both}.c-reading-companion__sticky{max-width:389px}.c-reading-companion__scroll-pane{margin:0;min-height:200px;overflow:hidden auto}.c-reading-companion__tabs{-webkit-box-orient:horizontal;-webkit-box-direction:normal;display:flex;flex-flow:row nowrap;font-size:1.6rem;list-style:none;margin:0 0 8px;padding:0}.c-reading-companion__tabs>li{-webkit-box-flex:1;flex-grow:1}.c-reading-companion__tab{background-color:#eee;border:1px solid #d5d5d5;border-image:initial;border-left-width:0;color:#069;font-size:1.6rem;padding:8px 8px 8px 15px;text-align:left;width:100%}.c-reading-companion__tabs li:first-child .c-reading-companion__tab{border-left-width:1px}.c-reading-companion__tab--active{background-color:#fff;border-bottom:1px solid #fff;color:#222;font-weight:700}.c-reading-companion__figures-list,.c-reading-companion__references-list,.c-reading-companion__sections-list{list-style:none;padding:0}.c-reading-companion__references-list--numeric{list-style:decimal inside}.c-reading-companion__sections-list{margin:0 0 8px;min-height:50px}.c-reading-companion__section-item{font-size:1.6rem;padding:0}.c-reading-companion__section-item a{display:block;line-height:1em;overflow:hidden;padding:8px 0 8px 16px;text-overflow:ellipsis;white-space:nowrap}.c-reading-companion__figure-item{border-top:1px solid #d5d5d5;font-size:1.6rem;padding:16px 8px 16px 0}.c-reading-companion__figure-item:first-child{border-top:none;padding-top:8px}.c-reading-companion__reference-item{border-top:1px solid #d5d5d5;font-size:1.6rem;padding:8px 8px 8px 16px}.c-reading-companion__reference-item:first-child{border-top:none}.c-reading-companion__reference-item a{word-break:break-word}.c-reading-companion__reference-citation{display:inline}.c-reading-companion__reference-links{font-size:1.3rem;font-weight:700;list-style:none;margin:8px 0 0;padding:0;text-align:right}.c-reading-companion__reference-links>a{display:inline-block;padding-left:8px}.c-reading-companion__reference-links>a:first-child{display:inline-block;padding-left:0}.c-reading-companion__figure-title{display:block;margin:0 0 8px}.c-reading-companion__figure-links{-webkit-box-pack:justify;display:flex;justify-content:space-between;margin:8px 0 0}.c-reading-companion__figure-links>a{display:inline-block}.c-reading-companion__panel{border-top:none;display:none;margin-top:0;padding-top:0}.c-reading-companion__panel--active{display:block}.c-pdf-download{display:flex;margin-bottom:24px;max-height:48px}@media only screen and (min-width:540px){.c-pdf-download{max-height:none}}@media only screen and (min-width:1024px){.c-pdf-download{max-height:48px}}.c-pdf-download__link{-webkit-box-pack:justify;-webkit-box-flex:1;background:#069;border:1px solid #069;border-radius:2px;color:#fff;display:flex;flex:1 1 0%;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;font-size:1.6rem;justify-content:space-between;line-height:1.3;padding:13px 24px;text-decoration:none}.c-article-metrics__heading a,.c-article-metrics__posts .c-card__title a{color:inherit}.c-article-metrics__posts .c-card__title{font-size:1.7rem}.c-article-metrics__posts .c-card__title+span{color:#6f6f6f;font-size:1.6rem}.c-ad{text-align:center}@media only screen and (min-width:320px){.c-ad{padding:8px}}.c-ad--728x90{background-color:#ccc;display:none}.c-ad--728x90 .c-ad__inner{min-height:calc(1.5em + 94px)}@media only screen and (min-width:768px){.js .c-ad--728x90{display:none}}.c-ad__label{color:#333;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;font-size:1.4rem;font-weight:400;line-height:1.5;margin-bottom:4px}.c-author-list{color:#6f6f6f;font-family:inherit;font-size:1.6rem;line-height:inherit;list-style:none;margin:0;padding:0}.c-author-list>li,.c-breadcrumbs>li,.c-footer__list--inline>li,.u-list-comma-separated>li,.u-list-inline>li{display:inline}.c-author-list>li:not(:first-child):not(:last-child):before{content:", "}.c-author-list>li:not(:only-child):last-child:before{content:" & "}.c-author-list--compact{font-size:1.4rem;line-height:1.4}.c-author-list--truncated>li:not(:only-child):last-child:before{content:" ... "}.c-skip-link{background:#069;color:#fff;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;font-size:1.4rem;padding:8px;position:absolute;text-align:center;transform:translateY(-100%);width:100%;z-index:9999}@media (prefers-reduced-motion:reduce){.c-skip-link{transition:top .3s ease-in-out 0s}}@media print{.c-skip-link{display:none}}.c-skip-link:link{color:#fff}.c-status-message{-webkit-box-align:center;align-items:center;display:flex;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;font-size:16px;position:relative;width:100%}.c-card__summary>p:last-child,.c-status-message :last-child{margin-bottom:0}.c-status-message--boxed{background-color:#fff;border:1px solid #eee;border-radius:2px;line-height:1.4;padding:16px}.c-status-message__heading{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;font-size:16px;font-weight:700}.c-status-message__icon{fill:currentcolor;-webkit-box-flex:0;display:inline-block;flex:0 0 auto;margin-right:8px;transform:translate(0);vertical-align:text-top}.c-status-message__icon--top{align-self:flex-start}.c-status-message--info .c-status-message__icon{color:#003f8d}.c-status-message--boxed.c-status-message--info{border-bottom:4px solid #003f8d}.c-status-message--error .c-status-message__icon{color:#c40606}.c-status-message--boxed.c-status-message--error{border-bottom:4px solid #c40606}.c-status-message--success .c-status-message__icon{color:#00b8b0}.c-status-message--boxed.c-status-message--success{border-bottom:4px solid #00b8b0}.c-status-message--warning .c-status-message__icon{color:#edbc53}.c-status-message--boxed.c-status-message--warning{border-bottom:4px solid #edbc53}.c-breadcrumbs{color:#000;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;font-size:16px;list-style:none;margin:0;padding:0}.c-breadcrumbs__link{color:#666}.c-breadcrumbs__chevron{margin:4px 4px 0}.c-card__body{-webkit-box-flex:1;flex:1 1 auto;padding:16px}.c-card__title{letter-spacing:-.01875rem;margin-bottom:8px}.c-card--flush .c-card__body{padding:0}.c-card--dark .c-card__title{color:#fff}.c-header{background-color:#fff;border-bottom:5px solid #000;font-size:1.6rem;line-height:1.4;margin-bottom:16px}.c-header__row{padding:8px 0;position:relative}.c-header__row:not(:last-child){border-bottom:1px solid #eee}.c-header__row--flush{padding:0}.c-header__split{-webkit-box-align:center;-webkit-box-pack:justify;align-items:center;display:flex;justify-content:space-between}.c-header__logo-container{-webkit-box-flex:1;flex:1 1 0px;line-height:0;margin-right:24px}.c-header__logo{transform:translateZ(0)}.c-header__logo img{max-height:32px}.c-header__container{margin:0 auto;max-width:1280px;padding:0 16px}.c-header__menu{-webkit-box-align:center;-webkit-box-flex:0;align-items:center;display:flex;flex:0 1 auto;flex-wrap:wrap;font-weight:700;line-height:1.4;list-style:none;margin:0 -8px;padding:0}.c-header__menu--global{-webkit-box-pack:end;font-weight:400;justify-content:flex-end}@media only screen and (min-width:540px){.c-header__menu--global .c-header__item svg{display:block}}.c-header__menu--journal{font-size:1.4rem}@media only screen and (min-width:540px){.c-header__menu--journal{flex-wrap:nowrap;font-size:1.6rem}}@media only screen and (max-width:1023px){.c-header__menu--tools{display:none}}.c-header__item{display:flex}@media only screen and (min-width:540px){.c-header__item:not(:first-child){margin-left:8px}}.c-header__item--pipe{border-left:2px solid #eee;padding-left:8px}@media only screen and (max-width:767px){.c-header__item--nature-research{display:none}}.c-header__row--flush .c-header__item{padding-bottom:8px;padding-top:8px}.c-header__link{-webkit-box-align:center;align-items:center;color:inherit;display:flex;padding:8px;white-space:nowrap}.c-header-expander a{color:inherit}.c-header__link>svg{margin-left:2px;transition-duration:.2s}@media only screen and (min-width:540px){.c-header__link>svg{margin-left:4px}}.c-header__show-text{display:none}@media only screen and (min-width:540px){.c-header__show-text{display:inline}.c-header__item--dropdown-menu{position:relative}}@media only screen and (min-width:540px){.c-header__menu--journal .c-header__item--dropdown-menu:last-child .c-header-expander.has-tethered{left:auto;right:0}}@media only screen and (min-width:768px){.c-header__menu--journal .c-header__item--dropdown-menu:last-child .c-header-expander.has-tethered{left:0;right:auto}}.c-header-expander{background-color:#000;border-bottom:1px solid #2f2f2f;color:#eee;font-size:1.4rem;line-height:1.2;padding:16px 0}.c-header-expander button{background-color:transparent;border:1px solid #fff;color:#fff}.c-header-expander__container{margin:0 auto;max-width:1280px;padding:0 16px}.c-header-expander__keyline{border-bottom:1px solid #555;margin-bottom:0;padding-bottom:16px}.c-header-expander__heading{display:inline-block;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;font-size:2rem;font-weight:400;line-height:1.4}.c-header-expander__list{display:flex;flex-wrap:wrap;margin:0;padding:0}.c-header-expander__item{margin:0 16px 8px 0}.c-header-expander__link{-webkit-box-align:center;align-items:center;color:inherit;display:flex;white-space:nowrap}.c-header-expander__link>svg{margin-left:8px}.c-header-expander.has-tethered{border-bottom:0;border-radius:0 0 2px 2px;left:0;position:absolute;top:100%;transform:translateY(5px);width:100%;z-index:1}@media only screen and (min-width:540px){.c-header-expander.has-tethered{transform:translateY(8px);width:auto}}@media only screen and (min-width:768px){.c-header-expander.has-tethered{min-width:225px}}.c-header-expander.has-tethered .c-header-expander__list{display:block}.c-header-expander.has-tethered .c-header-expander__item{margin:0;padding:8px 0}.c-header-expander.has-tethered .c-header-expander__item--keyline{border-top:1px solid #fff;margin-top:8px;padding-top:16px}.c-header-expander.has-tethered .c-header-expander__item--keyline-first-item-only~.c-header-expander__item--keyline-first-item-only{border-top:none;padding-top:0}.c-header-expander--tray.has-tethered{padding:32px 0 24px;transform:none;width:100%}.c-search{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;font-size:2rem;font-weight:400;line-height:1.3}.c-search--max-width{max-width:720px}.c-search__field{-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-box-align:center;align-items:center;display:flex;flex-flow:row wrap}.c-search__input-container{-webkit-box-flex:1;flex:1 0 100%;margin-bottom:8px}@media only screen and (min-width:768px){.c-search__input-container--md{-webkit-box-flex:999;flex:999 1 auto;margin-bottom:0;margin-right:16px}}.c-search__select-container{-webkit-box-flex:1;flex:1 1 auto;margin-bottom:8px}@media only screen and (min-width:540px){.c-search__select-container{-webkit-box-flex:999;flex:999 1 auto;margin-bottom:0;margin-right:16px}}@media only screen and (min-width:768px){.c-search__select-container{-webkit-box-flex:1;flex:1 0 auto}}.c-search__button-container{-webkit-box-flex:1;flex:1 0 100%}@media only screen and (min-width:540px){.c-search__button-container{-webkit-box-flex:1;flex:1 0 auto}}.c-search__input,.c-search__select{background-color:#fff;border:1px solid;border-radius:3px;box-sizing:border-box;font-size:1.6rem;padding:.6em 1em;width:100%}.c-search__select{-webkit-appearance:none;background-image:url("data:image/svg+xml,%3Csvg height=\'16\' viewBox=\'0 0 16 16\' width=\'16\' xmlns=\'http://www.w3.org/2000/svg\'%3E%3Cpath d=\'m5.58578644 3-3.29289322-3.29289322c-.39052429-.39052429-.39052429-1.02368927 0-1.41421356s1.02368927-.39052429 1.41421356 0l4 4c.39052429.39052429.39052429 1.02368927 0 1.41421356l-4 4c-.39052429.39052429-1.02368927.39052429-1.41421356 0s-.39052429-1.02368927 0-1.41421356z\' fill=\'%23333\' fill-rule=\'evenodd\' transform=\'matrix(0 1 -1 0 11 3)\'/%3E%3C/svg%3E");background-position:right .7em top 50%;background-repeat:no-repeat;background-size:1em;box-shadow:0 1px 0 1px rgba(0,0,0,.04);display:block;margin:0;max-width:100%;min-width:150px}.u-button{-webkit-box-align:center;-webkit-box-pack:center;align-items:center;background-color:transparent;background-image:none;border:1px solid #069;border-radius:2px;color:#069;cursor:pointer;display:inline-flex;font-family:sans-serif;font-size:1.6rem;justify-content:center;line-height:1.3;margin:0;padding:8px;position:relative;text-decoration:none;transition:all .25s ease 0s,color .25s ease 0s,border-color .25s ease 0s;width:auto}.u-button--primary{background-color:#069;background-image:none;border:1px solid #069;color:#fff}.u-button--full-width{display:flex;width:100%}.u-display-none{display:none}.js .u-js-hide,.u-hide{display:none;visibility:hidden}.u-visually-hidden{clip:rect(0,0,0,0);border:0;height:1px;margin:-100%;overflow:hidden;padding:0;position:absolute!important;width:1px}@media print{.u-hide-print{display:none}}@media only screen and (min-width:768px){.u-show-at-md{display:block;visibility:visible}}@media only screen and (min-width:1024px){.u-hide-at-lg{display:none;visibility:hidden}}.u-clearfix:after,.u-clearfix:before{content:"";display:table}.u-clearfix:after{clear:both}.u-float-left{float:left}.u-icon{fill:currentcolor;display:inline-block;transform:translate(0);vertical-align:text-top}.u-full-height{height:100%}.u-list-reset{list-style:none;margin:0;padding:0}.u-container{margin:0 auto;max-width:1280px;padding:0 16px}.u-display-inline-block{display:inline-block}.u-ma-0{margin:0}.u-mt-32{margin-top:32px}.u-mr-2{margin-right:2px}.u-mr-24{margin-right:24px}.u-mb-8{margin-bottom:8px}.u-mb-16{margin-bottom:16px}.u-mb-24{margin-bottom:24px}.u-mb-32{margin-bottom:32px}html *,html :after,html :before{box-sizing:inherit}.c-article-section__title,.c-article-title{font-weight:700}.c-card__title{line-height:1.4em}.c-header__link{text-decoration:inherit}.grade-c-hide{display:block}.u-lazy-ad-wrapper{background-color:#ccc;display:none;min-height:137px}@media only screen and (min-width:768px){.u-lazy-ad-wrapper{display:block}}</style>
+      \n\n        \n        \n        \n
+      <link data-inline-css-source="critical-css" rel="stylesheet" href="/static/css/article-nature-branded.0de00a62a0.css" media="print" onload="this.media=\'only screen and (-webkit-min-device-pixel-ratio:0) and (min-color-index:0), (-ms-high-contrast: none), only all and (min--moz-device-pixel-ratio:0) and (min-resolution: 3e1dpcm)\';this.onload=null">
+      \n
+      <noscript>
+         \n
+         <link rel="stylesheet" type="text/css" href="/static/css/article-nature-branded.0de00a62a0.css" media="only screen and (-webkit-min-device-pixel-ratio:0) and (min-color-index:0), (-ms-high-contrast: none), only all and (min--moz-device-pixel-ratio:0) and (min-resolution: 3e1dpcm)">
+         \n
+      </noscript>
+      \n        \n
+      <link rel="stylesheet" type="text/css" href="/static/css/article-print.950718ea76.css" media="print">
+      \n    \n\n\n
+      <link rel="apple-touch-icon" sizes="180x180" href=/static/images/favicons/nature/apple-touch-icon.f39cb19454.png>
+      \n
+      <link rel="icon" type="image/png" sizes="32x32" href=/static/images/favicons/nature/favicon-32x32.3fe59ece92.png>
+      \n
+      <link rel="icon" type="image/png" sizes="16x16" href=/static/images/favicons/nature/favicon-16x16.951651ab72.png>
+      \n
+      <link rel="manifest" href=/static/manifest.1a481c42b1.json crossorigin="use-credentials">
+      \n
+      <link rel="mask-icon" href=/static/images/favicons/nature/safari-pinned-tab.69bff48fe6.svg color="#000000">
+      \n
+      <link rel="shortcut icon" href=/static/images/favicons/nature/favicon.62367f778b.ico>
+      \n
+      <meta name="msapplication-TileColor" content="#000000">
+      \n
+      <meta name="msapplication-config" content=/static/browserconfig.e35b3b052c.xml>
+      \n
+      <meta name="theme-color" content="#000000">
+      \n
+      <meta name="application-name" content="Nature">
+      \n\n\n<script>\n    (function () {\n        if ( typeof window.CustomEvent === "function" ) return false;\n        function CustomEvent ( event, params ) {\n            params = params || { bubbles: false, cancelable: false, detail: null };\n            var evt = document.createEvent( \'CustomEvent\' );\n            evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );\n            return evt;\n        }\n\n        CustomEvent.prototype = window.Event.prototype;\n\n        window.CustomEvent = CustomEvent;\n    })();\n</script>\n\n\n\n    <script>\n    (function(w,d,t) {\n        function cc() {\n            var h = w.location.hostname;\n            if (h.indexOf(\'preview-www.nature.com\') > -1) return;\n\n            var e = d.createElement(t),\n                s = d.getElementsByTagName(t)[0];\n\n            if (h.indexOf(\'nature.com\') > -1) {\n                e.src = \'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js\';\n                e.setAttribute(\'data-domain-script\', \'83f2c78a-6cbc-4d1a-9088-3f8e8c4c7460\');\n            } else {\n                e.src = \'/static/js/cookie-consent-es5-bundle.34a145d526.js\';\n                e.setAttribute(\'data-consent\', h);\n            }\n            s.parentNode.insertBefore(e, s);\n        }\n\n        !!w.google_tag_manager ? cc() : window.addEventListener(\'gtm_loaded\', function() {cc()});\n    })(window,document,\'script\');\n</script>\n<script>\n    function OptanonWrapper() {\n        window.dataLayer.push({event:\'OneTrustGroupsUpdated\'});\n        document.activeElement.blur();\n    }\n</script>\n\n\n\n<script id="js-position0">\n    (function(w, d) {\n        w.idpVerifyPrefix = \'https://verify.nature.com\';\n        w.ra21Host = \'https://wayf.springernature.com\';\n        var moduleSupport = (function() {\n            return \'noModule\' in d.createElement(\'script\');\n        })();\n\n        var polyfillsUrl = function() {\n            var features = {\n                \'IntersectionObserver\': window.IntersectionObserver,\n                \'Promise\': window.Promise,\n                \'URLSearchParams\': window.URLSearchParams,\n                \'Symbol.iterator\': window.Symbol && Symbol.iterator,\n                \'Array.from\': Array.from,\n                \'Array.prototype.includes\': Array.prototype.includes,\n                \'Array.prototype.find\': Array.prototype.find,\n                \'Array.prototype.forEach\': Array.prototype.forEach,\n                \'NodeList.prototype.forEach\': NodeList.prototype.forEach,\n                \'Element.prototype.closest\': Element.prototype.closest,\n                \'Element.prototype.prepend\': Element.prototype.prepend,\n                \'Element.prototype.remove\': Element.prototype.remove,\n                \'Object.assign\': Object.assign\n            };\n            var req = [];\n            for (var feature in features) {\n                if (Object.prototype.hasOwnProperty.call(features, feature) && !features[feature]) {\n                    req.push(feature);\n                }\n            }\n            if (req.length) {\n                return \'https://polyfill.io/v3/polyfill.min.js?features=\' + req.join(\'%2C\') + \'&flags=always\';\n            }\n            return null;\n        };\n\n        if (w.config.mustardcut === true) {\n            w.loader = {\n                index: 0,\n                registered: [],\n                scripts: [\n                    {src: polyfillsUrl(), test: \'polyfills-js\', noinit: true},\n                    \n                        {src: \'/static/js/global-article-es6-bundle.7dc3dce534.js\', test: \'global-article-js\', module: true},\n                        {src: \'/static/js/global-article-es5-bundle.6c16769b0e.js\', test: \'global-article-js\', nomodule: true},\n                        {src: \'/static/js/shared-es6-bundle.bc701b2283.js\', test: \'shared-js\', module: true},\n                        {src: \'/static/js/shared-es5-bundle.6b94ed7e0e.js\', test: \'shared-js\', nomodule: true},\n                        {src: \'/static/js/header-150-es6-bundle.785ec93d66.js\', test: \'header-150-js\', module: true},\n                        {src: \'/static/js/header-150-es5-bundle.4f4f49f383.js\', test: \'header-150-js\', nomodule: true}\n                    \n                ].filter(function (s) {\n                    if (s.src === null) return false;\n                    if (moduleSupport && s.nomodule) return false;\n                    return !(!moduleSupport && s.module);\n                }),\n\n                register: function (value) {\n                    this.registered.push(value);\n                },\n\n                ready: function () {\n                    if (this.registered.length === this.scripts.length) {\n                        this.registered.forEach(function (fn) {\n                            if (typeof fn === \'function\') {\n                                setTimeout(fn, 0); \n                            }\n                        });\n                        this.ready = function () {};\n                    }\n                },\n\n                insert: function (s) {\n                    var t = d.getElementById(\'js-position\' + this.index);\n                    if (t && t.insertAdjacentElement) {\n                        t.insertAdjacentElement(\'afterend\', s);\n                    } else {\n                        d.head.appendChild(s);\n                    }\n                    ++this.index;\n                },\n\n                createScript: function (script, beforeLoad) {\n                    var s = d.createElement(\'script\');\n                    s.id = \'js-position\' + (this.index + 1);\n                    s.setAttribute(\'data-test\', script.test);\n                    if (beforeLoad) {\n                        s.defer = \'defer\';\n                        s.onload = function () {\n                            if (script.noinit) {\n                                loader.register(true);\n                            }\n                            if (d.readyState === \'interactive\' || d.readyState === \'complete\') {\n                                loader.ready();\n                            }\n                        };\n                    } else {\n                        s.async = \'async\';\n                    }\n                    s.src = script.src;\n                    return s;\n                },\n\n                init: function () {\n                    this.scripts.forEach(function (s) {\n                        loader.insert(loader.createScript(s, true));\n                    });\n\n                    d.addEventListener(\'DOMContentLoaded\', function () {\n                        loader.ready();\n                        \n                            var conditionalScripts = [\n                                {match: \'div[data-pan-container]\', src: \'/static/js/pan-zoom-es6-bundle.b5d6c3b38e.js\', test: \'pan-zoom-js\',  module: true },\n                                {match: \'div[data-pan-container]\', src: \'/static/js/pan-zoom-es5-bundle.40944b99f9.js\', test: \'pan-zoom-js\',  nomodule: true },\n                                {match: \'math,span.mathjax-tex\', src: \'/static/js/math.6a9dcb09ef.js\', test: \'math-js\'}\n                            ];\n                        \n\n                        if (conditionalScripts) {\n                            conditionalScripts.filter(function (script) {\n                                return !!document.querySelector(script.match) && !((moduleSupport && script.nomodule) || (!moduleSupport && script.module));\n                            }).forEach(function (script) {\n                                loader.insert(loader.createScript(script));\n                            });\n                        }\n                    }, false);\n                }\n            };\n            loader.init();\n        }\n    })(window, document);\n</script>\n\n\n    \n<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({\'gtm.start\':\n        new Date().getTime(),event:\'gtm.js\'});var f=d.getElementsByTagName(s)[0],\n    j=d.createElement(s),dl=l!=\'dataLayer\'?\'&l=\'+l:\'\';j.async=true;j.src=\n    \'https://www.googletagmanager.com/gtm.js?id=\'+i+dl;\n\n    \n    j.addEventListener(\'load\', function() {\n    var _ge = new CustomEvent(\'gtm_loaded\', { bubbles: true });\n    d.dispatchEvent(_ge);\n    });\n\n    f.parentNode.insertBefore(j,f);\n})(window,document,\'script\',\'dataLayer\',\'GTM-NWDMT9Q\');</script>\n\n\n\n\n\n
+      <meta name="robots" content="noarchive">
+      \n
+      <meta name="access" content="Yes">
+      \n
+      <meta name="WT.cg_s" content="Article"/>
+      \n
+      <meta name="WT.z_bandiera_abtest" content="a"/>
+      \n
+      <meta name="WT.page_categorisation" content="Article_HTML"/>
+      \n\n
+      <meta name="WT.template" content="oscar"/>
+      \n
+      <meta name="WT.z_cg_type" content="Nature Research Journals"/>
+      \n
+      <meta name="WT.cg_n" content="Nature Communications"/>
+      \n
+      <meta name="dc.rights" content="©2021 Macmillan Publishers Limited. All Rights Reserved."/>
+      \n
+      <meta name="prism.issn" content="2041-1723"/>
+      \n\n\n
+      <link rel="search" href="http://www.nature.com/search">
+      \n
+      <link rel="search" href="http://www.nature.com/opensearch/opensearch.xml" type="application/opensearchdescription+xml" title="nature.com">
+      \n
+      <link rel="search" href="http://www.nature.com/opensearch/request" type="application/sru+xml" title="nature.com">
+      \n\n\n\n    \n    <script type="application/ld+json">{"mainEntity":{"headline":"A cross-sectional analysis of meteorological factors and SARS-CoV-2 transmission in 409 cities across 26 countries","description":"There is conflicting evidence on the influence of weather on COVID-19 transmission. Our aim is to estimate weather-dependent signatures in the early phase of the pandemic, while controlling for socio-economic factors and non-pharmaceutical interventions. We identify a modest non-linear association between mean temperature and the effective reproduction number (Re) in 409 cities in 26 countries, with a decrease of 0.087 (95% CI: 0.025; 0.148) for a 10\u2009°C increase. Early interventions have a greater effect on Re with a decrease of 0.285 (95% CI 0.223; 0.347) for a 5th - 95th percentile increase in the government response index. The variation in the effective reproduction number explained by government interventions is 6 times greater than for mean temperature. We find little evidence of meteorological conditions having influenced the early stages of local epidemics and conclude that population behaviour and government interventions are more important drivers of transmission. Possible effects of weather conditions on COVID-19 transmission are debated. Here, the authors analyse data from early in the pandemic and show that although temperature and humidity had small effects on transmission, they were far out-weighed by the effects of non-pharmaceutical interventions.","datePublished":"2021-10-13","dateModified":"2021-10-13","pageStart":"1","pageEnd":"11","license":"http://creativecommons.org/licenses/by/4.0/","sameAs":"https://doi.org/10.1038/s41467-021-25914-8","keywords":"Climate sciences,Epidemiology,Risk factors,SARS-CoV-2,Science,Humanities and Social Sciences,multidisciplinary","image":"https://static-content.springer.com/image/art%3A10.1038%2Fs41467-021-25914-8/MediaObjects/41467_2021_25914_Fig1_HTML.png","isPartOf":{"name":"Nature Communications","issn":["2041-1723"],"volumeNumber":"12","@type":["Periodical","PublicationVolume"]},"publisher":{"name":"Nature Publishing Group UK","logo":{"url":"https://www.springernature.com/app-sn/public/images/logo-springernature.png","@type":"ImageObject"},"@type":"Organization"},"author":[{"name":"Sera, Francesco","affiliation":[{"name":"London School of Hygiene & Tropical Medicine","address":{"name":"Department of Public Health, Environments and Society, London School of Hygiene & Tropical Medicine, London, UK","@type":"PostalAddress"},"@type":"Organization"},{"name":"University of Florence","address":{"name":"Department of Statistics, Computer Science and Applications “G. Parenti”, University of Florence, Florence, Italy","@type":"PostalAddress"},"@type":"Organization"}],"@type":"Person"},{"name":"Armstrong, Ben","url":"http://orcid.org/0000-0003-4407-0409","affiliation":[{"name":"London School of Hygiene & Tropical Medicine","address":{"name":"Department of Public Health, Environments and Society, London School of Hygiene & Tropical Medicine, London, UK","@type":"PostalAddress"},"@type":"Organization"}],"@type":"Person"},{"name":"Abbott, Sam","affiliation":[{"name":"London School of Hygiene & Tropical Medicine","address":{"name":"Centre for Mathematical Modelling of Infectious Diseases, London School of Hygiene & Tropical Medicine, London, UK","@type":"PostalAddress"},"@type":"Organization"},{"name":"London School of Hygiene & Tropical Medicine","address":{"name":"Department of Infectious Disease Epidemiology, London School of Hygiene & Tropical Medicine, London, UK","@type":"PostalAddress"},"@type":"Organization"}],"@type":"Person"},{"name":"Meakin, Sophie","affiliation":[{"name":"London School of Hygiene & Tropical Medicine","address":{"name":"Centre for Mathematical Modelling of Infectious Diseases, London School of Hygiene & Tropical Medicine, London, UK","@type":"PostalAddress"},"@type":"Organization"},{"name":"London School of Hygiene & Tropical Medicine","address":{"name":"Department of Infectious Disease Epidemiology, London School of Hygiene & Tropical Medicine, London, UK","@type":"PostalAddress"},"@type":"Organization"}],"@type":"Person"},{"name":"O’Reilly, Kathleen","url":"http://orcid.org/0000-0002-4892-8022","affiliation":[{"name":"London School of Hygiene & Tropical Medicine","address":{"name":"Centre for Mathematical Modelling of Infectious Diseases, London School of Hygiene & Tropical Medicine, London, UK","@type":"PostalAddress"},"@type":"Organization"},{"name":"London School of Hygiene & Tropical Medicine","address":{"name":"Department of Infectious Disease Epidemiology, London School of Hygiene & Tropical Medicine, London, UK","@type":"PostalAddress"},"@type":"Organization"}],"@type":"Person"},{"name":"von Borries, Rosa","url":"http://orcid.org/0000-0002-4857-3452","affiliation":[{"name":"Charité Universitätsmedizin","address":{"name":"Charité Universitätsmedizin, Berlin, Germany","@type":"PostalAddress"},"@type":"Organization"}],"@type":"Person"},{"name":"Schneider, Rochelle","url":"http://orcid.org/0000-0002-2905-0154","affiliation":[{"name":"London School of Hygiene & Tropical Medicine","address":{"name":"Department of Public Health, Environments and Society, London School of Hygiene & Tropical Medicine, London, UK","@type":"PostalAddress"},"@type":"Organization"},{"name":"London School of Hygiene & Tropical Medicine","address":{"name":"Centre on Climate Change and Planetary Health, London School of Hygiene & Tropical Medicine, London, UK","@type":"PostalAddress"},"@type":"Organization"},{"name":"Forecast Department, European Centre for Medium-Range Weather Forecast (ECMWF)","address":{"name":"Forecast Department, European Centre for Medium-Range Weather Forecast (ECMWF), Reading, UK","@type":"PostalAddress"},"@type":"Organization"},{"name":"European Space Agency","address":{"name":"Φ-Lab, European Space Agency, Frascati, Italy","@type":"PostalAddress"},"@type":"Organization"}],"@type":"Person"},{"name":"Royé, Dominic","url":"http://orcid.org/0000-0002-5516-6396","affiliation":[{"name":"University of Santiago de Compostela","address":{"name":"Department of Geography, CIBER of Epidemiology and Public Health (CIBERESP), University of Santiago de Compostela, Santiago de Compostela, Spain","@type":"PostalAddress"},"@type":"Organization"}],"@type":"Person"},{"name":"Hashizume, Masahiro","url":"http://orcid.org/0000-0003-4720-1750","affiliation":[{"name":"Nagasaki University","address":{"name":"Department of Paediatric Infectious Disease, Institute of Tropical Medicine, Nagasaki University, Nagasaki, Japan","@type":"PostalAddress"},"@type":"Organization"},{"name":"Nagasaki University","address":{"name":"School of Tropical Medicine and Global Health, Nagasaki University, Nagasaki, Japan","@type":"PostalAddress"},"@type":"Organization"},{"name":"The University of Tokyo","address":{"name":"Department of Global Health Policy, Graduate School of Medicine, The University of Tokyo, Tokyo, Japan","@type":"PostalAddress"},"@type":"Organization"}],"@type":"Person"},{"name":"Pascal, Mathilde","affiliation":[{"name":"French National Public Health Agency","address":{"name":"Santé Publique France, Department of Environmental and Occupational Health, French National Public Health Agency, Saint Maurice, France","@type":"PostalAddress"},"@type":"Organization"}],"@type":"Person"},{"name":"Tobias, Aurelio","affiliation":[{"name":"Nagasaki University","address":{"name":"School of Tropical Medicine and Global Health, Nagasaki University, Nagasaki, Japan","@type":"PostalAddress"},"@type":"Organization"},{"name":"Spanish Council for Scientific Research (CSIS)","address":{"name":"Institute of Environmental Assessment and Water Research (IDAEA), Spanish Council for Scientific Research (CSIS), Barcelona, Spain","@type":"PostalAddress"},"@type":"Organization"}],"@type":"Person"},{"name":"Vicedo-Cabrera, Ana Maria","url":"http://orcid.org/0000-0001-6982-8867","affiliation":[{"name":"University of Bern","address":{"name":"Institute of Social and Preventive Medicine, University of Bern, Bern, Switzerland","@type":"PostalAddress"},"@type":"Organization"},{"name":"University of Bern","address":{"name":"Oeschger Center for Climate Change Research, University of Bern, Bern, Switzerland","@type":"PostalAddress"},"@type":"Organization"}],"@type":"Person"},{"name":"Gasparrini, Antonio","url":"http://orcid.org/0000-0002-2271-3568","affiliation":[{"name":"London School of Hygiene & Tropical Medicine","address":{"name":"Department of Public Health, Environments and Society, London School of Hygiene & Tropical Medicine, London, UK","@type":"PostalAddress"},"@type":"Organization"},{"name":"London School of Hygiene & Tropical Medicine","address":{"name":"Centre on Climate Change and Planetary Health, London School of Hygiene & Tropical Medicine, London, UK","@type":"PostalAddress"},"@type":"Organization"},{"name":"London School of Hygiene & Tropical Medicine","address":{"name":"Centre for Statistical Modelling, London School of Hygiene & Tropical Medicine, London, UK","@type":"PostalAddress"},"@type":"Organization"}],"@type":"Person"},{"name":"Lowe, Rachel","url":"http://orcid.org/0000-0003-3939-7343","affiliation":[{"name":"London School of Hygiene & Tropical Medicine","address":{"name":"Centre for Mathematical Modelling of Infectious Diseases, London School of Hygiene & Tropical Medicine, London, UK","@type":"PostalAddress"},"@type":"Organization"},{"name":"London School of Hygiene & Tropical Medicine","address":{"name":"Department of Infectious Disease Epidemiology, London School of Hygiene & Tropical Medicine, London, UK","@type":"PostalAddress"},"@type":"Organization"},{"name":"London School of Hygiene & Tropical Medicine","address":{"name":"Centre on Climate Change and Planetary Health, London School of Hygiene & Tropical Medicine, London, UK","@type":"PostalAddress"},"@type":"Organization"},{"name":"Barcelona Supercomputing Center","address":{"name":"Barcelona Supercomputing Center, Barcelona, Spain","@type":"PostalAddress"},"@type":"Organization"}],"@type":"Person"}],"@type":"ScholarlyArticle"},"@context":"https://schema.org","@type":"WebPage"}</script>\n\n\n\n    \n    \n\n
+      <meta name="journal_id" content="41467"/>
+      \n\n
+      <meta name="dc.title" content="A cross-sectional analysis of meteorological factors and SARS-CoV-2 transmission in 409 cities across 26 countries"/>
+      \n\n
+      <meta name="dc.source" content="Nature Communications 2021 12:1"/>
+      \n\n
+      <meta name="dc.format" content="text/html"/>
+      \n\n
+      <meta name="dc.publisher" content="Nature Publishing Group"/>
+      \n\n
+      <meta name="dc.date" content="2021-10-13"/>
+      \n\n
+      <meta name="dc.type" content="OriginalPaper"/>
+      \n\n
+      <meta name="dc.language" content="En"/>
+      \n\n
+      <meta name="dc.copyright" content="2021 The Author(s)"/>
+      \n\n
+      <meta name="dc.rightsAgent" content="journalpermissions@springernature.com"/>
+      \n\n
+      <meta name="dc.description" content="There is conflicting evidence on the influence of weather on COVID-19 transmission. Our aim is to estimate weather-dependent signatures in the early phase of the pandemic, while controlling for socio-economic factors and non-pharmaceutical interventions. We identify a modest non-linear association between mean temperature and the effective reproduction number (Re) in 409 cities in 26 countries, with a decrease of 0.087 (95% CI: 0.025; 0.148) for a 10&#8201;&#176;C increase. Early interventions have a greater effect on Re with a decrease of 0.285 (95% CI 0.223; 0.347) for a 5th - 95th percentile increase in the government response index. The variation in the effective reproduction number explained by government interventions is 6 times greater than for mean temperature. We find little evidence of meteorological conditions having influenced the early stages of local epidemics and conclude that population behaviour and government interventions are more important drivers of transmission. Possible effects of weather conditions on COVID-19 transmission are debated. Here, the authors analyse data from early in the pandemic and show that although temperature and humidity had small effects on transmission, they were far out-weighed by the effects of non-pharmaceutical interventions."/>
+      \n\n
+      <meta name="prism.issn" content="2041-1723"/>
+      \n\n
+      <meta name="prism.publicationName" content="Nature Communications"/>
+      \n\n
+      <meta name="prism.publicationDate" content="2021-10-13"/>
+      \n\n
+      <meta name="prism.volume" content="12"/>
+      \n\n
+      <meta name="prism.number" content="1"/>
+      \n\n
+      <meta name="prism.section" content="OriginalPaper"/>
+      \n\n
+      <meta name="prism.startingPage" content="1"/>
+      \n\n
+      <meta name="prism.endingPage" content="11"/>
+      \n\n
+      <meta name="prism.copyright" content="2021 The Author(s)"/>
+      \n\n
+      <meta name="prism.rightsAgent" content="journalpermissions@springernature.com"/>
+      \n\n
+      <meta name="prism.url" content="https://www.nature.com/articles/s41467-021-25914-8"/>
+      \n\n
+      <meta name="prism.doi" content="doi:10.1038/s41467-021-25914-8"/>
+      \n\n
+      <meta name="citation_pdf_url" content="https://www.nature.com/articles/s41467-021-25914-8.pdf"/>
+      \n\n
+      <meta name="citation_fulltext_html_url" content="https://www.nature.com/articles/s41467-021-25914-8"/>
+      \n\n
+      <meta name="citation_journal_title" content="Nature Communications"/>
+      \n\n
+      <meta name="citation_journal_abbrev" content="Nat Commun"/>
+      \n\n
+      <meta name="citation_publisher" content="Nature Publishing Group"/>
+      \n\n
+      <meta name="citation_issn" content="2041-1723"/>
+      \n\n
+      <meta name="citation_title" content="A cross-sectional analysis of meteorological factors and SARS-CoV-2 transmission in 409 cities across 26 countries"/>
+      \n\n
+      <meta name="citation_volume" content="12"/>
+      \n\n
+      <meta name="citation_issue" content="1"/>
+      \n\n
+      <meta name="citation_online_date" content="2021/10/13"/>
+      \n\n
+      <meta name="citation_firstpage" content="1"/>
+      \n\n
+      <meta name="citation_lastpage" content="11"/>
+      \n\n
+      <meta name="citation_article_type" content="Article"/>
+      \n\n
+      <meta name="citation_fulltext_world_readable" content=""/>
+      \n\n
+      <meta name="citation_language" content="en"/>
+      \n\n
+      <meta name="dc.identifier" content="doi:10.1038/s41467-021-25914-8"/>
+      \n\n
+      <meta name="DOI" content="10.1038/s41467-021-25914-8"/>
+      \n\n
+      <meta name="citation_doi" content="10.1038/s41467-021-25914-8"/>
+      \n\n
+      <meta name="description" content="There is conflicting evidence on the influence of weather on COVID-19 transmission. Our aim is to estimate weather-dependent signatures in the early phase of the pandemic, while controlling for socio-economic factors and non-pharmaceutical interventions. We identify a modest non-linear association between mean temperature and the effective reproduction number (Re) in 409 cities in 26 countries, with a decrease of 0.087 (95% CI: 0.025; 0.148) for a 10&#8201;&#176;C increase. Early interventions have a greater effect on Re with a decrease of 0.285 (95% CI 0.223; 0.347) for a 5th - 95th percentile increase in the government response index. The variation in the effective reproduction number explained by government interventions is 6 times greater than for mean temperature. We find little evidence of meteorological conditions having influenced the early stages of local epidemics and conclude that population behaviour and government interventions are more important drivers of transmission. Possible effects of weather conditions on COVID-19 transmission are debated. Here, the authors analyse data from early in the pandemic and show that although temperature and humidity had small effects on transmission, they were far out-weighed by the effects of non-pharmaceutical interventions."/>
+      \n\n
+      <meta name="dc.creator" content="Sera, Francesco"/>
+      \n\n
+      <meta name="dc.creator" content="Armstrong, Ben"/>
+      \n\n
+      <meta name="dc.creator" content="Abbott, Sam"/>
+      \n\n
+      <meta name="dc.creator" content="Meakin, Sophie"/>
+      \n\n
+      <meta name="dc.creator" content="O&#8217;Reilly, Kathleen"/>
+      \n\n
+      <meta name="dc.creator" content="von Borries, Rosa"/>
+      \n\n
+      <meta name="dc.creator" content="Schneider, Rochelle"/>
+      \n\n
+      <meta name="dc.creator" content="Roy&#233;, Dominic"/>
+      \n\n
+      <meta name="dc.creator" content="Hashizume, Masahiro"/>
+      \n\n
+      <meta name="dc.creator" content="Pascal, Mathilde"/>
+      \n\n
+      <meta name="dc.creator" content="Tobias, Aurelio"/>
+      \n\n
+      <meta name="dc.creator" content="Vicedo-Cabrera, Ana Maria"/>
+      \n\n
+      <meta name="dc.creator" content="Gasparrini, Antonio"/>
+      \n\n
+      <meta name="dc.creator" content="Lowe, Rachel"/>
+      \n\n
+      <meta name="dc.subject" content="Climate sciences"/>
+      \n\n
+      <meta name="dc.subject" content="Epidemiology"/>
+      \n\n
+      <meta name="dc.subject" content="Risk factors"/>
+      \n\n
+      <meta name="dc.subject" content="SARS-CoV-2"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Annu. Rev. Virol.; citation_title=Seasonality of respiratory viral infections.; citation_author=M Moriyama, WJ Hugentobler, A Iwasaki; citation_volume=7; citation_publication_date=2020; citation_pages=83-101; citation_doi=10.1146/annurev-virology-012420-022445; citation_id=CR1"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=J. Virol.; citation_title=Roles of humidity and temperature in shaping influenza seasonality; citation_author=AC Lowen, J Steel; citation_volume=88; citation_publication_date=2014; citation_pages=7692-7695; citation_doi=10.1128/JVI.03544-13; citation_id=CR2"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Nat. Commun.; citation_title=Misconceptions about weather and seasonality must not misguide COVID-19 response; citation_author=CJ Carlson, ACR Gomez, S Bansal, SJ Ryan; citation_volume=11; citation_publication_date=2020; citation_doi=10.1038/s41467-020-18150-z; citation_id=CR3"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Science; citation_title=Susceptible supply limits the role of climate in the early SARS-CoV-2 pandemic; citation_author=RE Baker, W Yang, GA Vecchi, CJE Metcalf, BT Grenfell; citation_volume=369; citation_publication_date=2020; citation_pages=315-319; citation_doi=10.1126/science.abc2535; citation_id=CR4"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Lancet Planet. Health; citation_title=Effective transmission across the globe: the role of climate in COVID-19 mitigation strategies; citation_author=KM O&#8217;Reilly; citation_volume=4; citation_publication_date=2020; citation_pages=e172; citation_doi=10.1016/S2542-5196(20)30106-6; citation_id=CR5"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Lancet Planet. Health; citation_title=Responding to COVID-19 requires strong epidemiological evidence of environmental and societal determining factors; citation_author=A Zeka; citation_volume=4; citation_publication_date=2020; citation_pages=e375-e376; citation_doi=10.1016/S2542-5196(20)30169-8; citation_id=CR6"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Int. J. Environ. Res. Public Health; citation_title=Short-term effects of ambient ozone, PM2.5, and meteorological factors on COVID-19 confirmed cases and deaths in Queens, New York; citation_author=A Adhikari, J Yin; citation_volume=17; citation_publication_date=2020; citation_pages=4047; citation_doi=10.3390/ijerph17114047; citation_id=CR7"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=J. Med. Virol.; citation_title=Ambient air pollution, meteorology, and COVID&#8208;19 infection in Korea; citation_author=T Hoang, TTA Tran; citation_volume=93; citation_publication_date=2021; citation_pages=878-885; citation_doi=10.1002/jmv.26325; citation_id=CR8"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Front. Public Health; citation_title=Evidence that higher temperatures are associated with a marginally lower incidence of COVID-19 cases; citation_author=A Meyer, R Sadler, C Faverjon, AR Cameron, M Bannister-Tyrrell; citation_volume=8; citation_publication_date=2020; citation_pages=367; citation_doi=10.3389/fpubh.2020.00367; citation_id=CR9"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=PeerJ; citation_title=Air transportation, population density and temperature predict the spread of COVID-19 in Brazil; citation_author=P Pequeno; citation_volume=8; citation_publication_date=2020; citation_pages=e9322; citation_doi=10.7717/peerj.9322; citation_id=CR10"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Sci. Total Environ.; citation_title=Short-term effects of specific humidity and temperature on COVID-19 morbidity in select US cities; citation_author=JD Runkle; citation_volume=740; citation_publication_date=2020; citation_pages=140093; citation_doi=10.1016/j.scitotenv.2020.140093; citation_id=CR11"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=JAMA Netw. Open; citation_title=Association of social distancing, population density, and temperature with the instantaneous reproduction number of SARS-CoV-2 in counties across the United States; citation_author=D Rubin; citation_volume=3; citation_publication_date=2020; citation_pages=e2016099; citation_doi=10.1001/jamanetworkopen.2020.16099; citation_id=CR12"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Can. Med. Assoc. J.; citation_title=Impact of climate and public health interventions on the COVID-19 pandemic: a prospective cohort study; citation_author=P J&#252;ni; citation_volume=192; citation_publication_date=2020; citation_pages=E566-E573; citation_doi=10.1503/cmaj.200920; citation_id=CR13"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Proc. Natl Acad. Sci. USA; citation_title=Global evidence for ultraviolet radiation decreasing COVID-19 growth rates; citation_author=T Carleton, J Cornetet, P Huybers, KC Meng, J Proctor; citation_volume=118; citation_publication_date=2021; citation_pages=e2012370118; citation_doi=10.1073/pnas.2012370118; citation_id=CR14"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Int. J. Environ. Res. Public Health; citation_title=Winter is coming: a Southern Hemisphere perspective of the environmental drivers of SARS-CoV-2 and the potential seasonality of COVID-19; citation_author=AJ Smit; citation_volume=17; citation_publication_date=2020; citation_pages=5634; citation_doi=10.3390/ijerph17165634; citation_id=CR15"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=PLoS ONE; citation_title=Effects of temperature and humidity on the spread of COVID-19: A systematic review; citation_author=P Mecenas, RT Bastos, RM da, ACR Vallinoto, D Normando; citation_volume=15; citation_publication_date=2020; citation_pages=e0238339; citation_doi=10.1371/journal.pone.0238339; citation_id=CR16"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Prog. Phys. Geogr. Earth Environ.; citation_title=The effect of climate on the spread of the COVID-19 pandemic: a review of findings, and statistical and modelling techniques; citation_author=&#193; Briz-Red&#243;n, &#193; Serrano-Aroca; citation_volume=44; citation_publication_date=2020; citation_pages=591-604; citation_doi=10.1177/0309133320946302; citation_id=CR17"/>
+      \n\n
+      <meta name="citation_reference" content="Abbott, S., Hellewell, J., Munday, J., Thompson, R. &amp; Funk, S. EpiNow: estimate realtime case counts and time-varying epidemiological parameters. Zenodo \n                  https://doi.org/10.5281/zenodo.3957489\n                  \n                 (2020)."/>
+      \n\n
+      <meta name="citation_reference" content="Hersbach, H. et al. ERA5 Hourly Data on Single Levels from 1979 to Present (Copernicus Climate Change Service (C3S) Climate Data Store (CDS), 2018)."/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Stat. Med.; citation_title=An extended mixed&#8208;effects framework for meta&#8208;analysis; citation_author=F Sera, B Armstrong, M Blangiardo, A Gasparrini; citation_volume=38; citation_publication_date=2019; citation_pages=5429-5444; citation_doi=10.1002/sim.8362; citation_id=CR20"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=J. Infect. Dis.; citation_title=Simulated sunlight rapidly inactivates SARS-CoV-2 on surfaces; citation_author=S Ratnesar-Shumate; citation_volume=222; citation_publication_date=2020; citation_pages=214-222; citation_doi=10.1093/infdis/jiaa274; citation_id=CR21"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=J. Infect. Dis.; citation_title=Airborne SARS-CoV-2 is rapidly inactivated by simulated sunlight; citation_author=M Schuit; citation_volume=222; citation_publication_date=2020; citation_pages=564-571; citation_doi=10.1093/infdis/jiaa334; citation_id=CR22"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=mSphere; citation_title=Increasing temperature and relative humidity accelerates inactivation of SARS-CoV-2 on surfaces; citation_author=J Biryukov; citation_volume=5; citation_publication_date=2020; citation_pages=e00441-20; citation_doi=10.1128/mSphere.00441-20; citation_id=CR23"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=J. Hosp. Infect.; citation_title=Factors affecting stability and infectivity of SARS-CoV-2; citation_author=K-H Chan; citation_volume=106; citation_publication_date=2020; citation_pages=226-231; citation_doi=10.1016/j.jhin.2020.07.009; citation_id=CR24"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Aerosol Sci. Technol.; citation_title=The influence of temperature, humidity, and simulated sunlight on the infectivity of SARS-CoV-2 in aerosols; citation_author=P Dabisch; citation_volume=55; citation_publication_date=2021; citation_pages=142-153; citation_doi=10.1080/02786826.2020.1829536; citation_id=CR25"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Nano Lett.; citation_title=COVID-19: effects of environmental conditions on the propagation of respiratory droplets; citation_author=L Zhao, Y Qi, P Luzzatto-Fegiz, Y Cui, Y Zhu; citation_volume=20; citation_publication_date=2020; citation_pages=7744-7750; citation_doi=10.1021/acs.nanolett.0c03331; citation_id=CR26"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=PLoS Pathog.; citation_title=Influenza virus transmission is dependent on relative humidity and temperature; citation_author=AC Lowen, S Mubareka, J Steel, P Palese; citation_volume=3; citation_publication_date=2007; citation_pages=e151; citation_doi=10.1371/journal.ppat.0030151; citation_id=CR27"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Epidemiol. Infect.; citation_title=Epidemic influenza and vitamin D; citation_author=JJ Cannell; citation_volume=134; citation_publication_date=2006; citation_pages=1129-1140; citation_doi=10.1017/S0950268806007175; citation_id=CR28"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Nutrients; citation_title=Evidence that vitamin D supplementation could reduce risk of influenza and COVID-19 infections and deaths; citation_author=WB Grant; citation_volume=12; citation_publication_date=2020; citation_pages=988; citation_doi=10.3390/nu12040988; citation_id=CR29"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Environ. Health Perspect.; citation_title=Global influenza seasonality: reconciling patterns across temperate and tropical regions; citation_author=J Tamerius; citation_volume=119; citation_publication_date=2011; citation_pages=439-445; citation_doi=10.1289/ehp.1002383; citation_id=CR30"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Int. J. Environ. Res. Public. Health; citation_title=Potential factors influencing repeated SARS outbreaks in China; citation_author=Z Sun, K Thilakavathy, SS Kumar, G He, SV Liu; citation_volume=17; citation_publication_date=2020; citation_pages=1633; citation_doi=10.3390/ijerph17051633; citation_id=CR31"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Proc. Natl Acad. Sci. USA; citation_title=Low ambient humidity impairs barrier function and innate resistance against influenza infection; citation_author=E Kudo; citation_volume=116; citation_publication_date=2019; citation_pages=10905-10910; citation_doi=10.1073/pnas.1902840116; citation_id=CR32"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Proc. Natl Acad. Sci. USA; citation_title=High ambient temperature dampens adaptive immune responses to influenza A virus infection; citation_author=M Moriyama, T Ichinohe; citation_volume=116; citation_publication_date=2019; citation_pages=3118-3125; citation_doi=10.1073/pnas.1815029116; citation_id=CR33"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Int. J. Prev. Med.; citation_title=Factors influencing the seasonal patterns of infectious diseases; citation_author=A Fares; citation_volume=4; citation_publication_date=2013; citation_pages=128-132; citation_id=CR34"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Sci. Total Environ.; citation_title=Effects of temperature and humidity on the daily new cases and new deaths of COVID-19 in 166 countries; citation_author=Y Wu; citation_volume=729; citation_publication_date=2020; citation_pages=139051; citation_doi=10.1016/j.scitotenv.2020.139051; citation_id=CR35"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Environ. Health Perspect.; citation_title=Methodological considerations for epidemiological studies of air pollution and the SARS and COVID-19 coronavirus outbreaks; citation_author=PJ Villeneuve, MS Goldberg; citation_volume=128; citation_publication_date=2020; citation_pages=095001; citation_doi=10.1289/EHP7411; citation_id=CR36"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Eur. Respir. J.; citation_title=Go slow to go fast: a plea for sustained scientific rigour in air pollution research during the COVID-19 pandemic; citation_author=DJJ Heederik, LAM Smit, RCH Vermeulen; citation_volume=56; citation_publication_date=2020; citation_pages=2001361; citation_doi=10.1183/13993003.01361-2020; citation_id=CR37"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Environ. Res.; citation_title=Time series regression model for infectious disease and weather; citation_author=C Imai, B Armstrong, Z Chalabi, P Mangtani, M Hashizume; citation_volume=142; citation_publication_date=2015; citation_pages=319-327; citation_doi=10.1016/j.envres.2015.06.040; citation_id=CR38"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=BMC Med.; citation_title=The impact of non-pharmaceutical interventions on SARS-CoV-2 transmission across 130 countries and territories; citation_author=Y Liu, C Morgenstern, J Kelly, R Lowe, M Jit; citation_volume=19; citation_publication_date=2021; citation_doi=10.1186/s12916-020-01872-8; citation_id=CR39"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Science; citation_title=Substantial undocumented infection facilitates the rapid dissemination of novel coronavirus (SARS-CoV-2); citation_author=R Li; citation_volume=368; citation_publication_date=2020; citation_pages=489-493; citation_doi=10.1126/science.abb3221; citation_id=CR40"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=J. Travel Med.; citation_title=High population densities catalyse the spread of COVID-19; citation_author=J Rockl&#246;v, H Sj&#246;din; citation_volume=27; citation_publication_date=2020; citation_pages=taaa038; citation_doi=10.1093/jtm/taaa038; citation_id=CR41"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Nat. Med.; citation_title=Age-dependent effects in the transmission and control of COVID-19 epidemics; citation_author=NG Davies; citation_volume=26; citation_publication_date=2020; citation_pages=1205-1211; citation_doi=10.1038/s41591-020-0962-9; citation_id=CR42"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Public Health; citation_title=Poverty, inequality and COVID-19: the forgotten vulnerable; citation_author=JA Patel; citation_volume=183; citation_publication_date=2020; citation_pages=110-111; citation_doi=10.1016/j.puhe.2020.05.006; citation_id=CR43"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Int. J. Environ. Res. Public. Health; citation_title=Evidence-based considerations exploring relations between SARS-CoV-2 pandemic and air pollution: involvement of PM2.5-mediated up-regulation of the viral receptor ACE-2; citation_author=M Borro; citation_volume=17; citation_publication_date=2020; citation_pages=5573; citation_doi=10.3390/ijerph17155573; citation_id=CR44"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Cardiovasc. Res.; citation_title=Regional and global contributions of air pollution to risk of death from COVID-19; citation_author=A Pozzer; citation_volume=116; citation_publication_date=2020; citation_pages=2247-2253; citation_doi=10.1093/cvr/cvaa288; citation_id=CR45"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Infect. Control Hosp. Epidemiol.; citation_title=Effect of ambient air pollutants and meteorological variables on COVID-19 incidence; citation_author=Y Jiang, X-J Wu, Y-J Guan; citation_volume=41; citation_publication_date=2020; citation_pages=1011-1015; citation_doi=10.1017/ice.2020.222; citation_id=CR46"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Int. J. Biometeorol.; citation_title=Paradoxical home temperatures during cold weather: a proof-of-concept study; citation_author=NRI Ryti, A Korpelainen, O Sepp&#228;nen, JJK Jaakkola; citation_volume=64; citation_publication_date=2020; citation_pages=2065-2076; citation_doi=10.1007/s00484-020-01998-7; citation_id=CR47"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=J. R. Soc. Interface; citation_title=Mechanistic insights into the effect of humidity on airborne influenza virus survival, transmission and incidence; citation_author=LC Marr, JW Tang, J Mullekom, SS Lakdawala; citation_volume=16; citation_publication_date=2019; citation_pages=20180298; citation_doi=10.1098/rsif.2018.0298; citation_id=CR48"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Indoor Air; citation_title=The relationship between indoor and outdoor temperature, apparent temperature, relative humidity, and absolute humidity; citation_author=JL Nguyen, J Schwartz, DW Dockery; citation_volume=24; citation_publication_date=2014; citation_pages=103-112; citation_doi=10.1111/ina.12052; citation_id=CR49"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Lancet; citation_title=Mortality risk attributable to high and low ambient temperature: a multicountry observational study; citation_author=A Gasparrini; citation_volume=386; citation_publication_date=2015; citation_pages=369-375; citation_doi=10.1016/S0140-6736(14)62114-0; citation_id=CR50"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Wellcome Open Res.; citation_title=Estimating the time-varying reproduction number of SARS-CoV-2 using national and subnational case counts; citation_author=S Abbott; citation_volume=5; citation_publication_date=2020; citation_pages=112; citation_doi=10.12688/wellcomeopenres.16006.1; citation_id=CR51"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Philos. Trans. R. Soc. B; citation_title=Exploring surveillance data biases when estimating the reproduction number: with insights into subpopulation transmission of Covid-19 in England; citation_author=K Sherratt; citation_volume=376; citation_publication_date=2021; citation_pages=20200283; citation_doi=10.1098/rstb.2020.0283; citation_id=CR52"/>
+      \n\n
+      <meta name="citation_reference" content="Stan Development Team. RStan: The R interface to Stan (Stan Development Team, 2020)."/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Wellcome Open Res.; citation_title=Estimating the time-varying reproduction number of SARS-CoV-2 using national and subnational case counts; citation_author=S Abbott; citation_volume=5; citation_publication_date=2020; citation_pages=112; citation_doi=10.12688/wellcomeopenres.16006.1; citation_id=CR54"/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Eurosurveillance; citation_title=Estimating the generation interval for coronavirus disease (COVID-19) based on symptom onset data, March 2020; citation_author=T Ganyani; citation_volume=25; citation_publication_date=2020; citation_pages=2000257; citation_doi=10.2807/1560-7917.ES.2020.25.17.2000257; citation_id=CR55"/>
+      \n\n
+      <meta name="citation_reference" content="Ferretti, L. et al. The timing of COVID-19 transmission. Preprint at medRxiv \n                  https://doi.org/10.1101/2020.09.04.20188516\n                  \n                 (2020)."/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Ann. Intern. Med.; citation_title=The incubation period of Coronavirus Disease 2019 (COVID-19) from publicly reported confirmed cases: estimation and application; citation_author=SA Lauer; citation_volume=172; citation_publication_date=2020; citation_pages=577-582; citation_doi=10.7326/M20-0504; citation_id=CR57"/>
+      \n\n
+      <meta name="citation_reference" content="Jun, C. Calculate water vapor measures from temperature and dew point. \n                  https://github.com/caijun/humidity\n                  \n                 (2019)."/>
+      \n\n
+      <meta name="citation_reference" content="Shi, P. et al. The impact of temperature and absolute humidity on the coronavirus disease 2019 (COVID-19) outbreak - evidence from China. Preprint at medRxiv \n                  https://doi.org/10.1101/2020.03.22.20038919\n                  \n                 (2020)."/>
+      \n\n
+      <meta name="citation_reference" content="OECD. OECD regions at a glance 2016. \n                  https://doi.org/10.1787/reg_glance-2016-en\n                  \n                 (2016)."/>
+      \n\n
+      <meta name="citation_reference" content="Simplemaps. World cities database. \n                  https://simplemaps.com/data/world-cities\n                  \n                 (2016)."/>
+      \n\n
+      <meta name="citation_reference" content="Christophe, Y. et al. Validation Report of the CAMS Near-Real-Time Global Atmospheric Composition Service: Period March&#8211;May 2019. Copernicus Atmosphere Monitoring Service (CAMS) Report (2019)."/>
+      \n\n
+      <meta name="citation_reference" content="Morcrette, J.-J. et al. Aerosol analysis and forecast in the European Centre for medium-range weather forecasts integrated forecast system: forward modeling. J. Geophys. Res. Atmos. 114, \n                  https://doi.org/10.1029/2008JD011235\n                  \n                 (2009)."/>
+      \n\n
+      <meta name="citation_reference" content="Benedetti, A. et al. Aerosol analysis and forecast in the European centre for medium-range weather forecasts integrated forecast system: 2. Data assimilation. J. Geophys. Res. Atmos. 114, \n                  https://doi.org/10.1029/2008JD011115\n                  \n                 (2009)."/>
+      \n\n
+      <meta name="citation_reference" content="Hale, T. et al. Variation in Government Responses to COVID-19. Blavatnik School of Government Working Paper. \n                  www.bsg.ox.ac.uk/covidtracker\n                  \n                 (2021)."/>
+      \n\n
+      <meta name="citation_reference" content="citation_journal_title=Stat. Med.; citation_title=Quantifying heterogeneity in a meta-analysis; citation_author=JPT Higgins, SG Thompson; citation_volume=21; citation_publication_date=2002; citation_pages=1539-1558; citation_doi=10.1002/sim.1186; citation_id=CR66"/>
+      \n\n
+      <meta name="citation_reference" content="Kramer, M. R2 statistics for mixed models. Conf. Appl. Stat. Agric. \n                  https://doi.org/10.4148/2475-7772.1142\n                  \n                 (2005)."/>
+      \n\n
+      <meta name="citation_reference" content="Sera, F., Abbott, S. &amp; Roy&#233;. Data and code to replicate the analysis of the paper. &#8216;A cross-sectional analysis of meteorological factors and SARS-CoV-2 transmission in 409 cities across 26 countries&#8217;. \n                  https://doi.org/10.5281/zenodo.5215842\n                  \n                 (2021)."/>
+      \n\n
+      <meta name="citation_author" content="Sera, Francesco"/>
+      \n\n
+      <meta name="citation_author_institution" content="Department of Public Health, Environments and Society, London School of Hygiene &amp; Tropical Medicine, London, UK"/>
+      \n\n
+      <meta name="citation_author_institution" content="Department of Statistics, Computer Science and Applications &#8220;G. Parenti&#8221;, University of Florence, Florence, Italy"/>
+      \n\n
+      <meta name="citation_author" content="Armstrong, Ben"/>
+      \n\n
+      <meta name="citation_author_institution" content="Department of Public Health, Environments and Society, London School of Hygiene &amp; Tropical Medicine, London, UK"/>
+      \n\n
+      <meta name="citation_author" content="Abbott, Sam"/>
+      \n\n
+      <meta name="citation_author_institution" content="Centre for Mathematical Modelling of Infectious Diseases, London School of Hygiene &amp; Tropical Medicine, London, UK"/>
+      \n\n
+      <meta name="citation_author_institution" content="Department of Infectious Disease Epidemiology, London School of Hygiene &amp; Tropical Medicine, London, UK"/>
+      \n\n
+      <meta name="citation_author" content="Meakin, Sophie"/>
+      \n\n
+      <meta name="citation_author_institution" content="Centre for Mathematical Modelling of Infectious Diseases, London School of Hygiene &amp; Tropical Medicine, London, UK"/>
+      \n\n
+      <meta name="citation_author_institution" content="Department of Infectious Disease Epidemiology, London School of Hygiene &amp; Tropical Medicine, London, UK"/>
+      \n\n
+      <meta name="citation_author" content="O&#8217;Reilly, Kathleen"/>
+      \n\n
+      <meta name="citation_author_institution" content="Centre for Mathematical Modelling of Infectious Diseases, London School of Hygiene &amp; Tropical Medicine, London, UK"/>
+      \n\n
+      <meta name="citation_author_institution" content="Department of Infectious Disease Epidemiology, London School of Hygiene &amp; Tropical Medicine, London, UK"/>
+      \n\n
+      <meta name="citation_author" content="von Borries, Rosa"/>
+      \n\n
+      <meta name="citation_author_institution" content="Charit&#233; Universit&#228;tsmedizin, Berlin, Germany"/>
+      \n\n
+      <meta name="citation_author" content="Schneider, Rochelle"/>
+      \n\n
+      <meta name="citation_author_institution" content="Department of Public Health, Environments and Society, London School of Hygiene &amp; Tropical Medicine, London, UK"/>
+      \n\n
+      <meta name="citation_author_institution" content="Centre on Climate Change and Planetary Health, London School of Hygiene &amp; Tropical Medicine, London, UK"/>
+      \n\n
+      <meta name="citation_author_institution" content="Forecast Department, European Centre for Medium-Range Weather Forecast (ECMWF), Reading, UK"/>
+      \n\n
+      <meta name="citation_author_institution" content="&#934;-Lab, European Space Agency, Frascati, Italy"/>
+      \n\n
+      <meta name="citation_author" content="Roy&#233;, Dominic"/>
+      \n\n
+      <meta name="citation_author_institution" content="Department of Geography, CIBER of Epidemiology and Public Health (CIBERESP), University of Santiago de Compostela, Santiago de Compostela, Spain"/>
+      \n\n
+      <meta name="citation_author" content="Hashizume, Masahiro"/>
+      \n\n
+      <meta name="citation_author_institution" content="Department of Paediatric Infectious Disease, Institute of Tropical Medicine, Nagasaki University, Nagasaki, Japan"/>
+      \n\n
+      <meta name="citation_author_institution" content="School of Tropical Medicine and Global Health, Nagasaki University, Nagasaki, Japan"/>
+      \n\n
+      <meta name="citation_author_institution" content="Department of Global Health Policy, Graduate School of Medicine, The University of Tokyo, Tokyo, Japan"/>
+      \n\n
+      <meta name="citation_author" content="Pascal, Mathilde"/>
+      \n\n
+      <meta name="citation_author_institution" content="Sant&#233; Publique France, Department of Environmental and Occupational Health, French National Public Health Agency, Saint Maurice, France"/>
+      \n\n
+      <meta name="citation_author" content="Tobias, Aurelio"/>
+      \n\n
+      <meta name="citation_author_institution" content="School of Tropical Medicine and Global Health, Nagasaki University, Nagasaki, Japan"/>
+      \n\n
+      <meta name="citation_author_institution" content="Institute of Environmental Assessment and Water Research (IDAEA), Spanish Council for Scientific Research (CSIS), Barcelona, Spain"/>
+      \n\n
+      <meta name="citation_author" content="Vicedo-Cabrera, Ana Maria"/>
+      \n\n
+      <meta name="citation_author_institution" content="Institute of Social and Preventive Medicine, University of Bern, Bern, Switzerland"/>
+      \n\n
+      <meta name="citation_author_institution" content="Oeschger Center for Climate Change Research, University of Bern, Bern, Switzerland"/>
+      \n\n
+      <meta name="citation_author" content="Gasparrini, Antonio"/>
+      \n\n
+      <meta name="citation_author_institution" content="Department of Public Health, Environments and Society, London School of Hygiene &amp; Tropical Medicine, London, UK"/>
+      \n\n
+      <meta name="citation_author_institution" content="Centre on Climate Change and Planetary Health, London School of Hygiene &amp; Tropical Medicine, London, UK"/>
+      \n\n
+      <meta name="citation_author_institution" content="Centre for Statistical Modelling, London School of Hygiene &amp; Tropical Medicine, London, UK"/>
+      \n\n
+      <meta name="citation_author" content="Lowe, Rachel"/>
+      \n\n
+      <meta name="citation_author_institution" content="Centre for Mathematical Modelling of Infectious Diseases, London School of Hygiene &amp; Tropical Medicine, London, UK"/>
+      \n\n
+      <meta name="citation_author_institution" content="Department of Infectious Disease Epidemiology, London School of Hygiene &amp; Tropical Medicine, London, UK"/>
+      \n\n
+      <meta name="citation_author_institution" content="Centre on Climate Change and Planetary Health, London School of Hygiene &amp; Tropical Medicine, London, UK"/>
+      \n\n
+      <meta name="citation_author_institution" content="Barcelona Supercomputing Center, Barcelona, Spain"/>
+      \n\n
+      <meta name="access_endpoint" content="https://www.nature.com/platform/readcube-access"/>
+      \n\n
+      <meta name="twitter:site" content="@NatureComms"/>
+      \n\n
+      <meta name="twitter:card" content="summary"/>
+      \n\n
+      <meta name="twitter:image:alt" content="Content cover image"/>
+      \n\n
+      <meta name="twitter:title" content="A cross-sectional analysis of meteorological..."/>
+      \n\n
+      <meta name="twitter:description" content="Nature Communications - Possible effects of weather conditions on COVID-19 transmission are debated. Here, the authors analyse data from early in the pandemic and show that although temperature and..."/>
+      \n\n
+      <meta name="twitter:image" content="https://media.springernature.com/full/springer-static/image/art%3A10.1038%2Fs41467-021-25914-8/MediaObjects/41467_2021_25914_Fig1_HTML.png"/>
+      \n\n
+      <meta name="WT.z_cc_license_type" content="cc_by"/>
+      \n\n
+      <meta name="WT.z_primary_atype" content="Research"/>
+      \n\n
+      <meta name="WT.z_subject_term" content="Climate sciences;Epidemiology;Risk factors;SARS-CoV-2"/>
+      \n\n
+      <meta name="WT.z_subject_term_id" content="climate-sciences;epidemiology;risk-factors;sars-cov-2"/>
+      \n\n\n    \n
+      <meta property="og:url" content="https://www.nature.com/articles/s41467-021-25914-8"/>
+      \n
+      <meta property="og:type" content="article"/>
+      \n
+      <meta property="og:site_name" content="Nature Communications"/>
+      \n
+      <meta property="og:title" content="A cross-sectional analysis of meteorological factors and SARS-CoV-2 transmission in 409 cities across 26 countries - Nature Communications"/>
+      \n
+      <meta property="og:description" content="Possible effects of weather conditions on COVID-19 transmission are debated. Here, the authors analyse data from early in the pandemic and show that although temperature and humidity had small effects on transmission, they were far out-weighed by the effects of non-pharmaceutical interventions."/>
+      \n
+      <meta property="og:image" content="https://media.springernature.com/m685/springer-static/image/art%3A10.1038%2Fs41467-021-25914-8/MediaObjects/41467_2021_25914_Fig1_HTML.png"/>
+      \n    \n    <script>\n        window.eligibleForRa21 = \'false\'; // required by js files for displaying the cobranding box (entitlement-box.js)\n    </script>\n
+   </head>
+   \n
+   <body class="article-page">
+      \n\n
+      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NWDMT9Q"\n                  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+      \n\n\n\n
+      <div class="position-relative cleared z-index-50 background-white" data-test="top-containers">
+         \n    <a class="c-skip-link" href="#content">Skip to main content</a>\n\n\n\n
+         <div class="c-grade-c-banner u-hide">
+            \n
+            <div class="c-grade-c-banner__container">
+               \n        \n
+               <p>Thank you for visiting nature.com. You are using a browser version with limited support for CSS. To obtain\n            the best experience, we recommend you use a more up to date browser (or turn off compatibility mode in\n            Internet Explorer). In the meantime, to ensure continued support, we are displaying the site without styles\n            and JavaScript.</p>
+               \n\n
+            </div>
+            \n
+         </div>
+         \n\n    \n\n
+         <div class="u-lazy-ad-wrapper">
+            \n
+            <div class="deferred-placeholder" data-replace="true"\n                 data-placeholder="/placeholder/v1/institutionalBanner?bpids=[bpids] #institutional-banner-container"></div>
+            \n
+            <aside class="c-ad c-ad--728x90">
+               \n
+               <div class="c-ad__inner" data-container-type="banner-advert">
+                  \n
+                  <p class="c-ad__label">Advertisement</p>
+                  \n                    \n        \n            \n    <div id="div-gpt-ad-top-1"\n         class="div-gpt-ad advert leaderboard js-ad text-center hide-print grade-c-hide"\n         data-ad-type="top"\n         data-pa11y-ignore\n         data-gpt\n         data-gpt-unitpath="/285/nature_communications/article"\n         data-gpt-sizes="728x90"\n         data-gpt-targeting="type=article;pos=top;artid=s41467-021-25914-8;doi=10.1038/s41467-021-25914-8;techmeta=129,141;subjmeta=106,174,308,326,4130,499,596,631,692,704;kwrd=Climate sciences,Epidemiology,Risk factors,SARS-CoV-2">\n
+                  <noscript>\n            <a href="//pubads.g.doubleclick.net/gampad/jump?iu=/285/nature_communications/article&amp;sz=728x90&amp;c=2052631833&amp;t=pos%3Dtop%26type%3Darticle%26artid%3Ds41467-021-25914-8%26doi%3D10.1038/s41467-021-25914-8%26techmeta%3D129,141%26subjmeta%3D106,174,308,326,4130,499,596,631,692,704%26kwrd%3DClimate sciences,Epidemiology,Risk factors,SARS-CoV-2">\n                <img data-test="gpt-advert-fallback-img"\n                     src="//pubads.g.doubleclick.net/gampad/ad?iu=/285/nature_communications/article&amp;sz=728x90&amp;c=2052631833&amp;t=pos%3Dtop%26type%3Darticle%26artid%3Ds41467-021-25914-8%26doi%3D10.1038/s41467-021-25914-8%26techmeta%3D129,141%26subjmeta%3D106,174,308,326,4130,499,596,631,692,704%26kwrd%3DClimate sciences,Epidemiology,Risk factors,SARS-CoV-2"\n                     alt="Advertisement"\n                     width="728"\n                     height="90"></a>\n        </noscript>
+                  \n
+               </div>
+               \n\n        \n    \n
+         </div>
+         \n            </aside>\n
+      </div>
+      \n
+      <header class="c-header" id="header" data-header data-track-component="nature-150-split-header" style="border-color:#e63323">
+         \n
+         <div class="c-header__row c-header__row--flush">
+            \n
+            <div class="c-header__container">
+               \n
+               <div class="c-header__split">
+                  \n                    \n                    \n
+                  <div class="c-header__logo-container">
+                     \n                        \n
+                     <a href="/ncomms"\n                           data-track="click" data-track-action="home" data-track-label="image">
+                        \n
+                        <picture class="c-header__logo">
+                           \n
+                           <source srcset="//media.springernature.com/full/nature-cms/uploads/product/ncomms/header-03d2e325c0a02f6df509e5730e9be304.svg" media="(min-width: 875px)">
+                           \n                                <img src="//media.springernature.com/full/nature-cms/uploads/product/ncomms/header-7001f06bc3fe2437048388e9f2f44215.svg" alt="Nature Communications">\n
+                        </picture>
+                        \n
+                     </a>
+                     \n                    \n
+                  </div>
+                  \n                    \n
+                  <ul class="c-header__menu c-header__menu--global">
+                     \n
+                     <li class="c-header__item c-header__item--nature-research">\n                            <a class="c-header__link" href="https://www.nature.com/siteindex" data-test="siteindex-link"\n                               data-track="click" data-track-action="open nature research index" data-track-label="link">\n                                <span>View all journals</span>\n                            </a>\n                        </li>
+                     \n
+                     <li class="c-header__item c-header__item--pipe">
+                        \n                            <a class="c-header__link"\n                               href="#search-menu"\n                               data-header-expander\n                               data-test="search-link" data-track="click" data-track-action="open search tray" data-track-label="button">\n                                <span>Search</span>
+                        <svg role="img" aria-hidden="true" focusable="false" height="22" width="22" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+                           <path d="M16.48 15.455c.283.282.29.749.007 1.032a.738.738 0 01-1.032-.007l-3.045-3.044a7 7 0 111.026-1.026zM8 14A6 6 0 108 2a6 6 0 000 12z"/>
+                        </svg>
+                        \n                            </a>\n
+                     </li>
+                     \n
+                     <li class="c-header__item">
+                        \n                            <a href="/nams/svc/myaccount"\n    id="my-account"\n    class="c-header__link placeholder"\n    data-test="login-link" data-track="click" data-track-action="my account" data-track-category="nature-150-split-header" data-track-label="link">\n    <span>My Account</span>
+                        <svg role="img" aria-hidden="true" focusable="false" height="22" width="22" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+                           <path d="M10.238 16.905a7.96 7.96 0 003.53-1.48c-.874-2.514-2.065-3.936-3.768-4.319V9.83a3.001 3.001 0 10-2 0v1.277c-1.703.383-2.894 1.805-3.767 4.319A7.96 7.96 0 009 17c.419 0 .832-.032 1.238-.095zm4.342-2.172a8 8 0 10-11.16 0c.757-2.017 1.84-3.608 3.49-4.322a4 4 0 114.182 0c1.649.714 2.731 2.305 3.488 4.322zM9 18A9 9 0 119 0a9 9 0 010 18z" fill="#333" fill-rule="evenodd"/>
+                        </svg>
+                        \n</a>\n<a href="https://idp.nature.com/authorize/natureuser?client_id&#x3D;grover&amp;redirect_uri&#x3D;https%3A%2F%2Fwww.nature.com%2Farticles%2Fs41467-021-25914-8"\n    id="login-button"\n    style="display: none;"\n    class="c-header__link placeholder"\n    data-test="login-link" data-track="click" data-track-action="login" data-track-category="nature-150-split-header" data-track-label="link">\n    <span>Login</span>
+                        <svg role="img" aria-hidden="true" focusable="false" height="22" width="22" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+                           <path d="M10.238 16.905a7.96 7.96 0 003.53-1.48c-.874-2.514-2.065-3.936-3.768-4.319V9.83a3.001 3.001 0 10-2 0v1.277c-1.703.383-2.894 1.805-3.767 4.319A7.96 7.96 0 009 17c.419 0 .832-.032 1.238-.095zm4.342-2.172a8 8 0 10-11.16 0c.757-2.017 1.84-3.608 3.49-4.322a4 4 0 114.182 0c1.649.714 2.731 2.305 3.488 4.322zM9 18A9 9 0 119 0a9 9 0 010 18z" fill="#333" fill-rule="evenodd"/>
+                        </svg>
+                        \n</a>\n\n
+                     </li>
+                     \n
+                  </ul>
+                  \n
+               </div>
+               \n
+            </div>
+            \n
+         </div>
+         \n        \n
+         <div class="c-header__row">
+            \n
+            <div class="c-header__container" data-test="c-header__container">
+               \n
+               <div class="c-header__split">
+                  \n
+                  <div class="c-header__split">
+                     \n
+                     <ul class="c-header__menu c-header__menu--journal">
+                        \n                                \n
+                        <li class="c-header__item c-header__item--dropdown-menu" data-test="explore-content-button">
+                           \n                                        <a href="#explore"\n                                           class="c-header__link c-header__link--chevron"\n                                           data-header-expander\n                                           data-test="menu-button--explore"\n                                           data-track="click" data-track-action="open explore expander" data-track-label="button">\n                                            <span><span class="c-header__show-text">Explore</span> content</span>
+                           <svg role="img" aria-hidden="true" focusable="false" height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg">
+                              <path d="m5.58578644 3-3.29289322-3.29289322c-.39052429-.39052429-.39052429-1.02368927 0-1.41421356s1.02368927-.39052429 1.41421356 0l4 4c.39052429.39052429.39052429 1.02368927 0 1.41421356l-4 4c-.39052429.39052429-1.02368927.39052429-1.41421356 0s-.39052429-1.02368927 0-1.41421356z" transform="matrix(0 1 -1 0 11 3)"/>
+                           </svg>
+                           \n                                        </a>\n
+                        </li>
+                        \n                                \n
+                        <li class="c-header__item c-header__item--dropdown-menu">
+                           \n                                    <a href="#about-the-journal"\n                                       class="c-header__link c-header__link--chevron"\n                                       data-header-expander\n                                       data-test="menu-button--about-the-journal"\n                                       data-track="click" data-track-action="open about the journal expander" data-track-label="button">\n                                        <span>About <span class="c-header__show-text">the journal</span></span>
+                           <svg role="img" aria-hidden="true" focusable="false" height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg">
+                              <path d="m5.58578644 3-3.29289322-3.29289322c-.39052429-.39052429-.39052429-1.02368927 0-1.41421356s1.02368927-.39052429 1.41421356 0l4 4c.39052429.39052429.39052429 1.02368927 0 1.41421356l-4 4c-.39052429.39052429-1.02368927.39052429-1.41421356 0s-.39052429-1.02368927 0-1.41421356z" transform="matrix(0 1 -1 0 11 3)"/>
+                           </svg>
+                           \n                                    </a>\n
+                        </li>
+                        \n                                \n
+                        <li class="c-header__item c-header__item--dropdown-menu u-mr-2" data-test="publish-with-us-button">
+                           \n                                        <a href="#publish-with-us"\n                                           class="c-header__link c-header__link--chevron c-header__link--dropdown-menu"\n                                           data-header-expander\n                                           data-test="menu-button--publish"\n                                           data-track="click" data-track-action="open publish with us expander" data-track-label="button">\n                                            <span>Publish <span class="c-header__show-text">with us</span></span>
+                           <svg role="img" aria-hidden="true" focusable="false" height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg">
+                              <path d="m5.58578644 3-3.29289322-3.29289322c-.39052429-.39052429-.39052429-1.02368927 0-1.41421356s1.02368927-.39052429 1.41421356 0l4 4c.39052429.39052429.39052429 1.02368927 0 1.41421356l-4 4c-.39052429.39052429-1.02368927.39052429-1.41421356 0s-.39052429-1.02368927 0-1.41421356z" transform="matrix(0 1 -1 0 11 3)"/>
+                           </svg>
+                           \n                                        </a>\n
+                        </li>
+                        \n                                \n
+                     </ul>
+                     \n\n                            \n
+                  </div>
+                  \n\n
+                  <ul class="c-header__menu c-header__menu--tools">
+                     \n                            \n
+                     <li class="c-header__item">
+                        \n                                    <a class="c-header__link"\n                                       href="https://www.nature.com/my-account/alerts/subscribe-journal?list-id&#x3D;264"\n                                       rel="nofollow"\n                                       data-track="click"\n                                       data-track-action="Sign up for alerts"\n                                       data-track-label="link (desktop site header)"\n                                       data-track-external>\n                                        <span>Sign up for alerts</span>
+                        <svg role="img" aria-hidden="true" focusable="false" height="18" viewBox="0 0 18 18" width="18" xmlns="http://www.w3.org/2000/svg">
+                           <path d="m4 10h2.5c.27614237 0 .5.2238576.5.5s-.22385763.5-.5.5h-3.08578644l-1.12132034 1.1213203c-.18753638.1875364-.29289322.4418903-.29289322.7071068v.1715729h14v-.1715729c0-.2652165-.1053568-.5195704-.2928932-.7071068l-1.7071068-1.7071067v-3.4142136c0-2.76142375-2.2385763-5-5-5-2.76142375 0-5 2.23857625-5 5zm3 4c0 1.1045695.8954305 2 2 2s2-.8954305 2-2zm-5 0c-.55228475 0-1-.4477153-1-1v-.1715729c0-.530433.21071368-1.0391408.58578644-1.4142135l1.41421356-1.4142136v-3c0-3.3137085 2.6862915-6 6-6s6 2.6862915 6 6v3l1.4142136 1.4142136c.3750727.3750727.5857864.8837805.5857864 1.4142135v.1715729c0 .5522847-.4477153 1-1 1h-4c0 1.6568542-1.3431458 3-3 3-1.65685425 0-3-1.3431458-3-3z" fill="#222"/>
+                        </svg>
+                        \n                                    </a>\n
+                     </li>
+                     \n                            \n                            \n
+                     <li class="c-header__item c-header__item--pipe">\n                                    <a class="c-header__link"\n                                       href="http://feeds.nature.com/ncomms/rss/current"\n                                       data-track="click"\n                                       data-track-action="rss feed"\n                                       data-track-label="link">\n                                        <span>RSS feed</span>\n                                    </a>\n                                </li>
+                     \n                            \n
+                  </ul>
+                  \n
+               </div>
+               \n
+            </div>
+            \n
+         </div>
+         \n        \n
+      </header>
+      \n\n\n    \n    \n
+      <nav class="u-mb-16 u-hide u-show-at-md" aria-label="breadcrumbs">
+         \n
+         <div class="u-container">
+            \n
+            <ol class="c-breadcrumbs" itemscope itemtype="https://schema.org/BreadcrumbList">
+               \n
+               <li class="c-breadcrumbs__item" id="breadcrumb0" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                  <a class="c-breadcrumbs__link"\n                               href="/" itemprop="item"\n                               data-track="click" data-track-action="breadcrumb" data-track-category="header" data-track-label="link:nature"><span itemprop="name">nature</span></a>
+                  <meta itemprop="position" content="1">
+                  \n
+                  <svg class="u-icon c-breadcrumbs__chevron" role="img" aria-hidden="true" focusable="false" height="10" viewBox="0 0 10 10" width="10"\n                                         xmlns="http://www.w3.org/2000/svg">
+                     \n
+                     <path d="m5.96738168 4.70639573 2.39518594-2.41447274c.37913917-.38219212.98637524-.38972225 1.35419292-.01894278.37750606.38054586.37784436.99719163-.00013556 1.37821513l-4.03074001 4.06319683c-.37758093.38062133-.98937525.38100976-1.367372-.00003075l-4.03091981-4.06337806c-.37759778-.38063832-.38381821-.99150444-.01600053-1.3622839.37750607-.38054587.98772445-.38240057 1.37006824.00302197l2.39538588 2.4146743.96295325.98624457z"\n                                              fill="#666" fill-rule="evenodd" transform="matrix(0 -1 1 0 0 10)"/>
+                     \n
+                  </svg>
+                  \n
+               </li>
+               <li class="c-breadcrumbs__item" id="breadcrumb1" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                  <a class="c-breadcrumbs__link"\n                               href="/ncomms" itemprop="item"\n                               data-track="click" data-track-action="breadcrumb" data-track-category="header" data-track-label="link:nature communications"><span itemprop="name">nature communications</span></a>
+                  <meta itemprop="position" content="2">
+                  \n
+                  <svg class="u-icon c-breadcrumbs__chevron" role="img" aria-hidden="true" focusable="false" height="10" viewBox="0 0 10 10" width="10"\n                                         xmlns="http://www.w3.org/2000/svg">
+                     \n
+                     <path d="m5.96738168 4.70639573 2.39518594-2.41447274c.37913917-.38219212.98637524-.38972225 1.35419292-.01894278.37750606.38054586.37784436.99719163-.00013556 1.37821513l-4.03074001 4.06319683c-.37758093.38062133-.98937525.38100976-1.367372-.00003075l-4.03091981-4.06337806c-.37759778-.38063832-.38381821-.99150444-.01600053-1.3622839.37750607-.38054587.98772445-.38240057 1.37006824.00302197l2.39538588 2.4146743.96295325.98624457z"\n                                              fill="#666" fill-rule="evenodd" transform="matrix(0 -1 1 0 0 10)"/>
+                     \n
+                  </svg>
+                  \n
+               </li>
+               <li class="c-breadcrumbs__item" id="breadcrumb2" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                  <a class="c-breadcrumbs__link"\n                               href="/ncomms/articles?type&#x3D;article" itemprop="item"\n                               data-track="click" data-track-action="breadcrumb" data-track-category="header" data-track-label="link:articles"><span itemprop="name">articles</span></a>
+                  <meta itemprop="position" content="3">
+                  \n
+                  <svg class="u-icon c-breadcrumbs__chevron" role="img" aria-hidden="true" focusable="false" height="10" viewBox="0 0 10 10" width="10"\n                                         xmlns="http://www.w3.org/2000/svg">
+                     \n
+                     <path d="m5.96738168 4.70639573 2.39518594-2.41447274c.37913917-.38219212.98637524-.38972225 1.35419292-.01894278.37750606.38054586.37784436.99719163-.00013556 1.37821513l-4.03074001 4.06319683c-.37758093.38062133-.98937525.38100976-1.367372-.00003075l-4.03091981-4.06337806c-.37759778-.38063832-.38381821-.99150444-.01600053-1.3622839.37750607-.38054587.98772445-.38240057 1.37006824.00302197l2.39538588 2.4146743.96295325.98624457z"\n                                              fill="#666" fill-rule="evenodd" transform="matrix(0 -1 1 0 0 10)"/>
+                     \n
+                  </svg>
+                  \n
+               </li>
+               <li class="c-breadcrumbs__item" id="breadcrumb3" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                  \n                                    <span itemprop="name">article</span>
+                  <meta itemprop="position" content="4">
+               </li>
+               \n
+            </ol>
+            \n
+         </div>
+         \n
+      </nav>
+      \n    \n\n\n\n    \n\n</div>\n\n\n
+      <div class="u-container u-mt-32 u-mb-32 u-clearfix" id="content" data-component="article-container"  data-container-type="article">
+         \n
+         <main class="c-article-main-column u-float-left js-main-column" data-track-component="article body">
+            \n        \n
+            <div class="c-context-bar u-hide" data-component="context-bar" aria-hidden="true">
+               \n
+               <div class="c-context-bar__container u-container">
+                  \n
+                  <div class="c-context-bar__title">\n                        A cross-sectional analysis of meteorological factors and SARS-CoV-2 transmission in 409 cities across 26 countries\n                    </div>
+                  \n                    \n    \n
+                  <div class="c-pdf-download u-clear-both">
+                     \n
+                     <a href="/articles/s41467-021-25914-8.pdf" class="c-pdf-download__link" data-article-pdf="true" data-readcube-pdf-url="true" data-test="download-pdf" data-draft-ignore="true" data-track="click" data-track-action="download pdf" data-track-label="link" data-track-external>
+                        \n            <span>Download PDF</span>\n
+                        <svg aria-hidden="true" focusable="false" width="16" height="16" class="u-icon">
+                           <use xlink:href="#global-icon-download"/>
+                        </svg>
+                        \n
+                     </a>
+                     \n
+                  </div>
+                  \n    \n\n
+               </div>
+               \n
+            </div>
+            \n        \n
+            <article lang="en">
+               \n
+               <div class="c-article-header">
+                  \n
+                  <header>
+                     \n
+                     <ul class="c-article-identifiers" data-test="article-identifier">
+                        \n                        \n    \n
+                        <li class="c-article-identifiers__item" data-test="article-category">Article</li>
+                        \n    \n    \n
+                        <li class="c-article-identifiers__item">\n            <span class="c-article-identifiers__open" data-test="open-access">Open Access</span>\n        </li>
+                        \n    \n    \n\n
+                        <li class="c-article-identifiers__item"><a href="#article-info" data-track="click" data-track-action="publication date" data-track-label="link">Published: <time datetime="2021-10-13">13 October 2021</time></a></li>
+                        \n
+                     </ul>
+                     \n\n                    \n
+                     <h1 class="c-article-title" data-test="article-title" data-article-title="">A cross-sectional analysis of meteorological factors and SARS-CoV-2 transmission in 409 cities across 26 countries</h1>
+                     \n
+                     <ul class="c-article-author-list js-etal-collapsed" data-etal="25" data-etal-small="3" data-test="authors-list" data-component-authors-activator="authors-list">
+                        <li class="c-article-author-list__item">
+                           <a data-test="author-name" data-track="click" data-track-action="open author" data-track-label="link" href="#auth-Francesco-Sera" data-author-popup="auth-Francesco-Sera" data-corresp-id="c1">
+                              Francesco Sera
+                              <svg width="16" height="16" focusable="false" role="img" aria-hidden="true" class="u-icon">
+                                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#global-icon-email"></use>
+                              </svg>
+                           </a>
+                           <sup class="u-js-hide"><a href="#Aff1">1</a>,<a href="#Aff2">2</a></sup>,
+                        </li>
+                        <li class="c-article-author-list__item"><a data-test="author-name" data-track="click" data-track-action="open author" data-track-label="link" href="#auth-Ben-Armstrong" data-author-popup="auth-Ben-Armstrong">Ben Armstrong</a><span class="u-js-hide">\xa0\n            <a class="js-orcid" href="http://orcid.org/0000-0003-4407-0409"><span class="u-visually-hidden">ORCID: </span>orcid.org/0000-0003-4407-0409</a></span><sup class="u-js-hide"><a href="#Aff1">1</a></sup>, </li>
+                        <li class="c-article-author-list__item"><a data-test="author-name" data-track="click" data-track-action="open author" data-track-label="link" href="#auth-Sam-Abbott" data-author-popup="auth-Sam-Abbott">Sam Abbott</a><sup class="u-js-hide"><a href="#Aff3">3</a>,<a href="#Aff4">4</a></sup>, </li>
+                        <li class="c-article-author-list__item"><a data-test="author-name" data-track="click" data-track-action="open author" data-track-label="link" href="#auth-Sophie-Meakin" data-author-popup="auth-Sophie-Meakin">Sophie Meakin</a><sup class="u-js-hide"><a href="#Aff3">3</a>,<a href="#Aff4">4</a></sup>, </li>
+                        <li class="c-article-author-list__item"><a data-test="author-name" data-track="click" data-track-action="open author" data-track-label="link" href="#auth-Kathleen-O_Reilly" data-author-popup="auth-Kathleen-O_Reilly">Kathleen O’Reilly</a><span class="u-js-hide">\xa0\n            <a class="js-orcid" href="http://orcid.org/0000-0002-4892-8022"><span class="u-visually-hidden">ORCID: </span>orcid.org/0000-0002-4892-8022</a></span><sup class="u-js-hide"><a href="#Aff3">3</a>,<a href="#Aff4">4</a></sup>, </li>
+                        <li class="c-article-author-list__item"><a data-test="author-name" data-track="click" data-track-action="open author" data-track-label="link" href="#auth-Rosa-Borries" data-author-popup="auth-Rosa-Borries">Rosa von Borries</a><span class="u-js-hide">\xa0\n            <a class="js-orcid" href="http://orcid.org/0000-0002-4857-3452"><span class="u-visually-hidden">ORCID: </span>orcid.org/0000-0002-4857-3452</a></span><sup class="u-js-hide"><a href="#Aff5">5</a></sup>, </li>
+                        <li class="c-article-author-list__item"><a data-test="author-name" data-track="click" data-track-action="open author" data-track-label="link" href="#auth-Rochelle-Schneider" data-author-popup="auth-Rochelle-Schneider">Rochelle Schneider</a><span class="u-js-hide">\xa0\n            <a class="js-orcid" href="http://orcid.org/0000-0002-2905-0154"><span class="u-visually-hidden">ORCID: </span>orcid.org/0000-0002-2905-0154</a></span><sup class="u-js-hide"><a href="#Aff1">1</a>,<a href="#Aff6">6</a>,<a href="#Aff7">7</a>,<a href="#Aff8">8</a></sup>, </li>
+                        <li class="c-article-author-list__item"><a data-test="author-name" data-track="click" data-track-action="open author" data-track-label="link" href="#auth-Dominic-Roy_" data-author-popup="auth-Dominic-Roy_">Dominic Royé</a><span class="u-js-hide">\xa0\n            <a class="js-orcid" href="http://orcid.org/0000-0002-5516-6396"><span class="u-visually-hidden">ORCID: </span>orcid.org/0000-0002-5516-6396</a></span><sup class="u-js-hide"><a href="#Aff9">9</a></sup>, </li>
+                        <li class="c-article-author-list__item"><a data-test="author-name" data-track="click" data-track-action="open author" data-track-label="link" href="#auth-Masahiro-Hashizume" data-author-popup="auth-Masahiro-Hashizume">Masahiro Hashizume</a><span class="u-js-hide">\xa0\n            <a class="js-orcid" href="http://orcid.org/0000-0003-4720-1750"><span class="u-visually-hidden">ORCID: </span>orcid.org/0000-0003-4720-1750</a></span><sup class="u-js-hide"><a href="#Aff10">10</a>,<a href="#Aff11">11</a>,<a href="#Aff12">12</a></sup>, </li>
+                        <li class="c-article-author-list__item"><a data-test="author-name" data-track="click" data-track-action="open author" data-track-label="link" href="#auth-Mathilde-Pascal" data-author-popup="auth-Mathilde-Pascal">Mathilde Pascal</a><sup class="u-js-hide"><a href="#Aff13">13</a></sup>, </li>
+                        <li class="c-article-author-list__item"><a data-test="author-name" data-track="click" data-track-action="open author" data-track-label="link" href="#auth-Aurelio-Tobias" data-author-popup="auth-Aurelio-Tobias">Aurelio Tobias</a><sup class="u-js-hide"><a href="#Aff11">11</a>,<a href="#Aff14">14</a></sup>, </li>
+                        <li class="c-article-author-list__item"><a data-test="author-name" data-track="click" data-track-action="open author" data-track-label="link" href="#auth-Ana_Maria-Vicedo_Cabrera" data-author-popup="auth-Ana_Maria-Vicedo_Cabrera">Ana Maria Vicedo-Cabrera</a><span class="u-js-hide">\xa0\n            <a class="js-orcid" href="http://orcid.org/0000-0001-6982-8867"><span class="u-visually-hidden">ORCID: </span>orcid.org/0000-0001-6982-8867</a></span><sup class="u-js-hide"><a href="#Aff15">15</a>,<a href="#Aff16">16</a></sup>, </li>
+                        <li class="c-article-author-list__item"><a data-test="author-name" data-author-popup="group-1" href="#group-1">MCC Collaborative Research Network</a>, </li>
+                        <li class="c-article-author-list__item"><a data-test="author-name" data-author-popup="group-2" href="#group-2">CMMID COVID-19 Working Group</a>, </li>
+                        <li class="c-article-author-list__item"><a data-test="author-name" data-track="click" data-track-action="open author" data-track-label="link" href="#auth-Antonio-Gasparrini" data-author-popup="auth-Antonio-Gasparrini">Antonio Gasparrini</a><span class="u-js-hide">\xa0\n            <a class="js-orcid" href="http://orcid.org/0000-0002-2271-3568"><span class="u-visually-hidden">ORCID: </span>orcid.org/0000-0002-2271-3568</a></span><sup class="u-js-hide"><a href="#Aff1">1</a>,<a href="#Aff6">6</a>,<a href="#Aff17">17</a></sup> &amp; </li>
+                        <li class="c-article-author-list__item">
+                           <a data-test="author-name" data-track="click" data-track-action="open author" data-track-label="link" href="#auth-Rachel-Lowe" data-author-popup="auth-Rachel-Lowe" data-corresp-id="c2">
+                              Rachel Lowe
+                              <svg width="16" height="16" focusable="false" role="img" aria-hidden="true" class="u-icon">
+                                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#global-icon-email"></use>
+                              </svg>
+                           </a>
+                           <span class="u-js-hide">\xa0\n            <a class="js-orcid" href="http://orcid.org/0000-0003-3939-7343"><span class="u-visually-hidden">ORCID: </span>orcid.org/0000-0003-3939-7343</a></span><sup class="u-js-hide"><a href="#Aff3">3</a>,<a href="#Aff4">4</a>,<a href="#Aff6">6</a>,<a href="#Aff18">18</a></sup>\xa0
+                        </li>
+                     </ul>
+                     \n\n                    \n\n
+                     <p class="c-article-info-details" data-container-section="info">\n                        \n    <a data-test="journal-link" href="/ncomms"><i data-test="journal-title">Nature Communications</i></a>\n\n                        <b data-test="journal-volume"><span class="u-visually-hidden">volume</span>\xa012</b>, Article\xa0number:\xa0<span data-test="article-number">5968</span> (<span data-test="article-publication-year">2021</span>)\n            <a href="#citeas" class="c-article-info-details__cite-as u-hide-print" data-track="click" data-track-action="cite this article" data-track-label="link">Cite this article</a>\n                    </p>
+                     \n                    \n
+                     <div class="c-article-metrics-bar__wrapper u-clear-both">
+                        \n
+                        <ul class="c-article-metrics-bar u-list-reset">
+                           \n            \n
+                           <li class=" c-article-metrics-bar__item">
+                              \n
+                              <p class="c-article-metrics-bar__count">2753 <span class="c-article-metrics-bar__label">Accesses</span></p>
+                              \n
+                           </li>
+                           \n            \n            \n            \n                \n
+                           <li class="c-article-metrics-bar__item">
+                              \n
+                              <p class="c-article-metrics-bar__count">77 <span class="c-article-metrics-bar__label">Altmetric</span></p>
+                              \n
+                           </li>
+                           \n                \n            \n
+                           <li class="c-article-metrics-bar__item">
+                              \n
+                              <p class="c-article-metrics-bar__details"><a href="/articles/s41467-021-25914-8/metrics" data-track="click" data-track-action="view metrics" data-track-label="link" rel="nofollow">Metrics <span class="u-visually-hidden">details</span></a></p>
+                              \n
+                           </li>
+                           \n
+                        </ul>
+                        \n
+                     </div>
+                     \n\n
+                  </header>
+                  \n\n                \n
+                  <div class="u-js-hide" data-component="article-subject-links">
+                     \n
+                     <h3 class="c-article__sub-heading">Subjects</h3>
+                     \n
+                     <ul class="c-article-subject-list">
+                        \n
+                        <li class="c-article-subject-list__subject"><a href="/subjects/climate-sciences" data-track="click" data-track-action="view subject" data-track-label="link">Climate sciences</a></li>
+                        <li class="c-article-subject-list__subject"><a href="/subjects/epidemiology" data-track="click" data-track-action="view subject" data-track-label="link">Epidemiology</a></li>
+                        <li class="c-article-subject-list__subject"><a href="/subjects/risk-factors" data-track="click" data-track-action="view subject" data-track-label="link">Risk factors</a></li>
+                        <li class="c-article-subject-list__subject"><a href="/subjects/sars-cov-2" data-track="click" data-track-action="view subject" data-track-label="link">SARS-CoV-2</a></li>
+                        \n
+                     </ul>
+                     \n
+                  </div>
+                  \n\n                \n    \n\n    \n\n                \n
+               </div>
+               \n\n
+               <div class="c-article-body">
+                  \n
+                  <section aria-labelledby="Abs1" data-title="Abstract" lang="en">
+                     <div class="c-article-section" id="Abs1-section">
+                        <h2 class="c-article-section__title js-section-title js-c-reading-companion-sections-item" id="Abs1">Abstract</h2>
+                        <div class="c-article-section__content" id="Abs1-content">
+                           <p>There is conflicting evidence on the influence of weather on COVID-19 transmission. Our aim is to estimate weather-dependent signatures in the early phase of the pandemic, while controlling for socio-economic factors and non-pharmaceutical interventions. We identify a modest non-linear association between mean temperature and the effective reproduction number (R<sub>e</sub>) in 409 cities in 26 countries, with a decrease of 0.087 (95% CI: 0.025; 0.148) for a 10\u2009°C increase. Early interventions have a greater effect on R<sub>e</sub> with a decrease of 0.285 (95% CI 0.223; 0.347) for a 5th - 95th percentile increase in the government response index. The variation in the effective reproduction number explained by government interventions is 6 times greater than for mean temperature. We find little evidence of meteorological conditions having influenced the early stages of local epidemics and conclude that population behaviour and government interventions are more important drivers of transmission.</p>
+                        </div>
+                     </div>
+                  </section>
+                  \n
+                  <noscript>\n                \n            </noscript>
+                  \n\n            \n
+                  <div class="c-pdf-button__container">
+                     \n                    \n                        \n    \n
+                     <div class="c-pdf-download u-clear-both">
+                        \n
+                        <a href="/articles/s41467-021-25914-8.pdf" class="c-pdf-download__link" data-article-pdf="true" data-readcube-pdf-url="true" data-test="download-pdf" data-draft-ignore="true" data-track="click" data-track-action="download pdf" data-track-label="link" data-track-external>
+                           \n            <span>Download PDF</span>\n
+                           <svg aria-hidden="true" focusable="false" width="16" height="16" class="u-icon">
+                              <use xlink:href="#global-icon-download"/>
+                           </svg>
+                           \n
+                        </a>
+                        \n
+                     </div>
+                     \n    \n\n                    \n
+                  </div>
+                  \n            \n            \n
+                  <section data-title="Introduction">
+                     <div class="c-article-section" id="Sec1-section">
+                        <h2 class="c-article-section__title js-section-title js-c-reading-companion-sections-item" id="Sec1">Introduction</h2>
+                        <div class="c-article-section__content" id="Sec1-content">
+                           <p>Severe acute respiratory syndrome coronavirus 2 (SARS-CoV-2) has rapidly spread across the globe, traversing diverse climatic and environmental conditions. Sustained local transmission has occurred in most countries, leading to political, social and economic challenges and devastating loss of life. From the early phase of the pandemic, there has been speculation that weather conditions could modulate SARS-CoV-2 transmission patterns. The debate has been driven by analogy with existing seasonal endemic respiratory viral infections, such as influenza and other human coronaviruses, which tend to peak in the drier and colder winter months in temperate climates<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 1" title="Moriyama, M., Hugentobler, W. J. &amp; Iwasaki, A. Seasonality of respiratory viral infections.Annu. Rev. Virol. 7, 83–101 (2020)." href="/articles/s41467-021-25914-8#ref-CR1" id="ref-link-section-d7564002e2584">1</a></sup>. However, specific mechanisms behind this seasonality, in terms of host immunity and susceptibility, viral stability or weather-sensitive human behaviour are poorly understood<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 2" title="Lowen, A. C. &amp; Steel, J. Roles of humidity and temperature in shaping influenza seasonality. J. Virol. 88, 7692–7695 (2014)." href="/articles/s41467-021-25914-8#ref-CR2" id="ref-link-section-d7564002e2588">2</a></sup>. Dynamic transmission modelling has shown that meteorological variables, such as temperature and humidity, are unlikely to have been a dominant transmission risk factor in the early stages of the COVID-19 pandemic, given high population susceptibility<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 3" title="Carlson, C. J., Gomez, A. C. R., Bansal, S. &amp; Ryan, S. J. Misconceptions about weather and seasonality must not misguide COVID-19 response. Nat. Commun. 11, 4312 (2020)." href="/articles/s41467-021-25914-8#ref-CR3" id="ref-link-section-d7564002e2592">3</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 4" title="Baker, R. E., Yang, W., Vecchi, G. A., Metcalf, C. J. E. &amp; Grenfell, B. T. Susceptible supply limits the role of climate in the early SARS-CoV-2 pandemic. Science 369, 315–319 (2020)." href="/articles/s41467-021-25914-8#ref-CR4" id="ref-link-section-d7564002e2595">4</a></sup>. As SARS-CoV-2 is a new virus to humans, with &lt;1 year of data available at the time of writing, ascertaining the potential for weather modulated transmission is challenging. Several studies have attempted such analyses. However, many such studies had methodological weaknesses and the results were at times conflicting<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 5" title="O’Reilly, K. M. et al. Effective transmission across the globe: the role of climate in COVID-19 mitigation strategies. Lancet Planet. Health 4, e172 (2020)." href="/articles/s41467-021-25914-8#ref-CR5" id="ref-link-section-d7564002e2599">5</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 6" title="Zeka, A. et al. Responding to COVID-19 requires strong epidemiological evidence of environmental and societal determining factors. Lancet Planet. Health 4, e375–e376 (2020)." href="/articles/s41467-021-25914-8#ref-CR6" id="ref-link-section-d7564002e2602">6</a></sup>. Study findings for temperature resulted in either a positive<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 7" title="Adhikari, A. &amp; Yin, J. Short-term effects of ambient ozone, PM2.5, and meteorological factors on COVID-19 confirmed cases and deaths in Queens, New York. Int. J. Environ. Res. Public Health 17, 4047 (2020)." href="/articles/s41467-021-25914-8#ref-CR7" id="ref-link-section-d7564002e2606">7</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 8" title="Hoang, T. &amp; Tran, T. T. A. Ambient air pollution, meteorology, and COVID‐19 infection in Korea. J. Med. Virol. 93, 878–885 (2021)." href="/articles/s41467-021-25914-8#ref-CR8" id="ref-link-section-d7564002e2609">8</a></sup>, negative<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 9" title="Meyer, A., Sadler, R., Faverjon, C., Cameron, A. R. &amp; Bannister-Tyrrell, M. Evidence that higher temperatures are associated with a marginally lower incidence of COVID-19 cases. Front. Public Health 8, 367 (2020)." href="/articles/s41467-021-25914-8#ref-CR9" id="ref-link-section-d7564002e2614">9</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 10" title="Pequeno, P. et al. Air transportation, population density and temperature predict the spread of COVID-19 in Brazil. PeerJ 8, e9322 (2020)." href="/articles/s41467-021-25914-8#ref-CR10" id="ref-link-section-d7564002e2617">10</a></sup>, non-linear<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 11" title="Runkle, J. D. et al. Short-term effects of specific humidity and temperature on COVID-19 morbidity in select US cities. Sci. Total Environ. 740, 140093 (2020)." href="/articles/s41467-021-25914-8#ref-CR11" id="ref-link-section-d7564002e2621">11</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 12" title="Rubin, D. et al. Association of social distancing, population density, and temperature with the instantaneous reproduction number of SARS-CoV-2 in counties across the United States. JAMA Netw. Open 3, e2016099 (2020)." href="/articles/s41467-021-25914-8#ref-CR12" id="ref-link-section-d7564002e2624">12</a></sup> or non-significant association<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 13" title="Jüni, P. et al. Impact of climate and public health interventions on the COVID-19 pandemic: a prospective cohort study. Can. Med. Assoc. J. 192, E566–E573 (2020)." href="/articles/s41467-021-25914-8#ref-CR13" id="ref-link-section-d7564002e2628">13</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 14" title="Carleton, T., Cornetet, J., Huybers, P., Meng, K. C. &amp; Proctor, J. Global evidence for ultraviolet radiation decreasing COVID-19 growth rates. Proc. Natl Acad. Sci. USA 118, e2012370118 (2021)." href="/articles/s41467-021-25914-8#ref-CR14" id="ref-link-section-d7564002e2631">14</a></sup> with the COVID-19 response variable. For example, most studies did not control for key modulating factors, such as varying government restrictions, socio-economic indicators, population density or age structure<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" title="Smit, A. J. et al. Winter is coming: a Southern Hemisphere perspective of the environmental drivers of SARS-CoV-2 and the potential seasonality of COVID-19. Int. J. Environ. Res. Public Health 17, 5634 (2020)." href="#ref-CR15" id="ref-link-section-d7564002e2635">15</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" title="Mecenas, P., Bastos, R. T., da, R. M., Vallinoto, A. C. R. &amp; Normando, D. Effects of temperature and humidity on the spread of COVID-19: A systematic review. PLoS ONE 15, e0238339 (2020)." href="#ref-CR16" id="ref-link-section-d7564002e2635_1">16</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 17" title="Briz-Redón, Á. &amp; Serrano-Aroca, Á. The effect of climate on the spread of the COVID-19 pandemic: a review of findings, and statistical and modelling techniques. Prog. Phys. Geogr. Earth Environ. 44, 591–604 (2020)." href="/articles/s41467-021-25914-8#ref-CR17" id="ref-link-section-d7564002e2638">17</a></sup>.</p>
+                           <p>In this study, we overcome methodological issues of previous approaches by using a two-stage ecological modelling approach to examine the impact of meteorological variables on SARS-CoV-2 transmission by comparing cities located across the globe, while accounting for confounding of non-pharmaceutical interventions (NPIs) and city-level covariates. The study is based on an extensive dataset, collected by the Multi-Country Multi-City MCC Collaborative Research Network (<a href="https://mccstudy.lshtm.ac.uk/">https://mccstudy.lshtm.ac.uk/</a>), consisting of time series of daily COVID-19 cases registered between 11 January and 28 April 2020 in 409 locations (cities or small regions) in 26 countries. In the first stage, we estimated the effective reproduction number (<i>R</i><sub>e</sub>), in each city, over a city-specific time window early in the epidemic. We use a renewal equation-based approach that estimates latent infections and then map these infections to observed notifications via an incubation period, a report delay and a negative binomial observation model with a day of the week effect<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 18" title="Abbott, S., Hellewell, J., Munday, J., Thompson, R. &amp; Funk, S. EpiNow: estimate realtime case counts and time-varying epidemiological parameters. Zenodo &#xA;                  https://doi.org/10.5281/zenodo.3957489&#xA;                  &#xA;                 (2020)." href="/articles/s41467-021-25914-8#ref-CR18" id="ref-link-section-d7564002e2656">18</a></sup>. Focusing on the early phase of the pandemic allows us to minimise possible biases coming from factors impacting <i>R</i><sub>e</sub> (in particular non-pharmaceutical interventions (NPIs)), which developed as the pandemic progressed. These include change of ascertainment methods and strategies, the implementation of strong NPIs (e.g. travel bans, school closures and lockdown), the appearance of new variants and ultimately vaccination campaigns. Also,\xa0in the first stage\xa0we define our exposure variables as mean values of meteorological variables (including daily mean temperature, relative and absolute humidity, solar radiation, wind speed and precipitation), for each city, over the early-phase time window, using the ERA5 fifth-generation European Centre for Medium-Range Weather Forecast atmospheric reanalysis of the global climate<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 19" title="Hersbach, H. et al. ERA5 Hourly Data on Single Levels from 1979 to Present (Copernicus Climate Change Service (C3S) Climate Data Store (CDS), 2018)." href="/articles/s41467-021-25914-8#ref-CR19" id="ref-link-section-d7564002e2665">19</a></sup>. In a second ‘cross-sectional’ stage, we estimate the association of\xa0city-level <i>R</i><sub>e</sub>, calculated for the city-specific window (allowing for standard errors), with each meteorological variable, controlling for confounding by total population, population density, gross domestic product (GDP) per capita, percentage of population &gt;65 years, pollution levels (i.e. particulate matter, PM<sub>2.5</sub>) and the lagged Oxford COVID-19 Government Response Tracker (OxCGRT) Government Response Index at the endpoint of the selected time window (lagged by 10 days), allowing for the two-level (cities and countries) structure of the data using a multilevel meta-regression model<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 20" title="Sera, F., Armstrong, B., Blangiardo, M. &amp; Gasparrini, A. An extended mixed‐effects framework for meta‐analysis. Stat. Med. 38, 5429–5444 (2019)." href="/articles/s41467-021-25914-8#ref-CR20" id="ref-link-section-d7564002e2675">20</a></sup> (see ‘Methods’ for further details). We believe the data used and the analysis performed in this study improves upon previous approaches. Specifically, the fine spatial scale of the city-level data and the methodological design, accounting for confounding of NPIs and city-level covariates, allows us to accurately quantify the relationship between meteorological variables and <i>R</i><sub>e</sub>.</p>
+                        </div>
+                     </div>
+                  </section>
+                  <section data-title="Results">
+                     <div class="c-article-section" id="Sec2-section">
+                        <h2 class="c-article-section__title js-section-title js-c-reading-companion-sections-item" id="Sec2">Results</h2>
+                        <div class="c-article-section__content" id="Sec2-content">
+                           <h3 class="c-article__sub-heading" id="Sec3">Descriptive analysis of meteorological variables and <i>R</i>\n                           <sub>e</sub>\n                        </h3>
+                           <p>The bivariate distribution of mean temperature and the effective reproduction number (<i>R</i><sub>e</sub>) across the 409 study cities is shown in Fig.\xa0<a data-track="click" data-track-label="link" data-track-action="figure anchor" href="/articles/s41467-021-25914-8#Fig1">1</a>, and the characteristics of the 26 countries are reported in Table\xa0<a data-track="click" data-track-label="link" data-track-action="table anchor" href="/articles/s41467-021-25914-8#Tab1">1</a>. The mean effective reproduction number (<i>R</i><sub>e</sub>) across all cities was 1.4, ranging from 0.7 to 2.1, with all but ten cities experiencing an epidemic curve with a reproduction number &gt;1. Mean temperatures over the observation period (between January and April 2020) reflect the late winter/early spring in 381 cities situated in the northern hemisphere and the summer/early autumn seasons in 28 cities in the southern hemisphere. Of the 136 cities classified as having high <i>R</i><sub>e</sub> values, 35 cities experienced low temperatures, 64 medium temperatures and 34 high temperatures (Fig.\xa0<a data-track="click" data-track-label="link" data-track-action="figure anchor" href="/articles/s41467-021-25914-8#Fig1">1</a>). When visualising the unadjusted association of <i>R</i><sub>e</sub> with mean temperature, relative humidity (RH), absolute humidity (AH), solar radiation at the surface and stratified by climate zone, we found no clear pattern (Fig.\xa0<a data-track="click" data-track-label="link" data-track-action="figure anchor" href="/articles/s41467-021-25914-8#Fig2">2</a>).</p>
+                           <div class="c-article-section__figure js-c-reading-companion-figures-item" data-test="figure" data-container-section="figure" id="figure-1" data-title="Effective reproduction number and mean temperature in the observation window for 409 cities.">
+                              <figure>
+                                 <figcaption><b id="Fig1" class="c-article-section__figure-caption" data-test="figure-caption-text">Fig. 1: Effective reproduction number and mean temperature in the observation window for 409 cities.</b></figcaption>
+                                 <div class="c-article-section__figure-content">
+                                    <div class="c-article-section__figure-item">
+                                       <a class="c-article-section__figure-link" data-test="img-link" data-track="click" data-track-label="image" data-track-action="view figure" href="/articles/s41467-021-25914-8/figures/1" rel="nofollow">
+                                          <picture>
+                                             <source type="image/webp" srcset="//media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fs41467-021-25914-8/MediaObjects/41467_2021_25914_Fig1_HTML.png?as=webp"></source>
+                                             <img aria-describedby="Fig1" src="//media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fs41467-021-25914-8/MediaObjects/41467_2021_25914_Fig1_HTML.png" alt="figure1" loading="lazy" width="685" height="550" />
+                                          </picture>
+                                       </a>
+                                    </div>
+                                    <div class="c-article-section__figure-description" data-test="bottom-caption" id="figure-1-desc">
+                                       <p>Bivariate plot of effective reproduction number (<i>R</i><sub>e</sub>) and mean temperature (Ta) (°C) in the observation window for each of the 409 study cities. Dark purple circles represent cities with both high <i>R</i><sub>e</sub> and high Ta, while pale purple circles show areas with both low <i>R</i><sub>e</sub> and low Ta. Red circles represent cities with low <i>R</i><sub>e</sub> and high Ta and blue circles depict areas with high <i>R</i><sub>e</sub> and low Ta. The bar chart (bottom right) represents the number of cities in each category defined in the bivariate legend (bottom left).</p>
+                                    </div>
+                                 </div>
+                                 <div class="u-text-right u-hide-print">
+                                    <a class="c-article__pill-button" data-test="article-link" data-track="click" data-track-label="button" data-track-action="view figure" href="/articles/s41467-021-25914-8/figures/1" data-track-dest="link:Figure1 Full size image" aria-label="Full size image figure 1" rel="nofollow">
+                                       <span>Full size image</span>
+                                       <svg width="16" height="16" focusable="false" role="img" aria-hidden="true" class="u-icon">
+                                          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#global-icon-chevron-right"></use>
+                                       </svg>
+                                    </a>
+                                 </div>
+                              </figure>
+                           </div>
+                           <div class="c-article-table" data-test="inline-table" data-container-section="table" id="table-1">
+                              <figure>
+                                 <figcaption class="c-article-table__figcaption"><b id="Tab1" data-test="table-caption">Table 1 Characteristics of the 26 countries included in the study.</b></figcaption>
+                                 <div class="u-text-right u-hide-print">
+                                    <a class="c-article__pill-button" data-test="table-link" data-track="click" data-track-action="view table" data-track-label="button" rel="nofollow" href="/articles/s41467-021-25914-8/tables/1" aria-label="Full size table 1">
+                                       <span>Full size table</span>
+                                       <svg width="16" height="16" focusable="false" role="img" aria-hidden="true" class="u-icon">
+                                          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#global-icon-chevron-right"></use>
+                                       </svg>
+                                    </a>
+                                 </div>
+                              </figure>
+                           </div>
+                           <div class="c-article-section__figure js-c-reading-companion-figures-item" data-test="figure" data-container-section="figure" id="figure-2" data-title="Effective reproduction number vs key weather variables by climate zone.">
+                              <figure>
+                                 <figcaption><b id="Fig2" class="c-article-section__figure-caption" data-test="figure-caption-text">Fig. 2: Effective reproduction number vs key weather variables by climate zone.</b></figcaption>
+                                 <div class="c-article-section__figure-content">
+                                    <div class="c-article-section__figure-item">
+                                       <a class="c-article-section__figure-link" data-test="img-link" data-track="click" data-track-label="image" data-track-action="view figure" href="/articles/s41467-021-25914-8/figures/2" rel="nofollow">
+                                          <picture>
+                                             <source type="image/webp" srcset="//media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fs41467-021-25914-8/MediaObjects/41467_2021_25914_Fig2_HTML.png?as=webp"></source>
+                                             <img aria-describedby="Fig2" src="//media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fs41467-021-25914-8/MediaObjects/41467_2021_25914_Fig2_HTML.png" alt="figure2" loading="lazy" width="685" height="479" />
+                                          </picture>
+                                       </a>
+                                    </div>
+                                    <div class="c-article-section__figure-description" data-test="bottom-caption" id="figure-2-desc">
+                                       <p><b>a</b> Mean temperature (°C), <b>b</b> relative humidity (%), <b>c</b> absolute humidity (g/m<sup>3</sup>) and <b>d</b> solar surface radiation (J/m<sup>2</sup>) vs effective reproduction number (<i>R</i><sub>e</sub>) by climate zone (409 cities). The area of the circles is proportional to the precision (inverse of the variance) of <i>R</i><sub>e</sub> estimates.</p>
+                                    </div>
+                                 </div>
+                                 <div class="u-text-right u-hide-print">
+                                    <a class="c-article__pill-button" data-test="article-link" data-track="click" data-track-label="button" data-track-action="view figure" href="/articles/s41467-021-25914-8/figures/2" data-track-dest="link:Figure2 Full size image" aria-label="Full size image figure 2" rel="nofollow">
+                                       <span>Full size image</span>
+                                       <svg width="16" height="16" focusable="false" role="img" aria-hidden="true" class="u-icon">
+                                          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#global-icon-chevron-right"></use>
+                                       </svg>
+                                    </a>
+                                 </div>
+                              </figure>
+                           </div>
+                           <h3 class="c-article__sub-heading" id="Sec4">Associations between meteorological variables and <i>R</i>\n                           <sub>e</sub>\n                        </h3>
+                           <p>Using a two-stage meta-regression model, we quantified the influence of meteorological variables, including mean temperature, on <i>R</i><sub>e</sub> between cities, while controlling for confounding factors including government interventions. After adjusting for the city-level characteristics (e.g. socio-economic and demographic factors) and the country’s OxCGRT Government Response Index, we found a modest, non-linear association of mean temperature and AH with <i>R</i><sub>e</sub> (Table\xa0<a data-track="click" data-track-label="link" data-track-action="table anchor" href="/articles/s41467-021-25914-8#Tab2">2</a>). Less strong evidence of association was found for RH, with no evidence of association for solar radiation, wind speed and precipitation (Table\xa0<a data-track="click" data-track-label="link" data-track-action="table anchor" href="/articles/s41467-021-25914-8#Tab2">2</a>). The association between mean temperature and <i>R</i><sub>e</sub> is non-linear, with <i>R</i><sub>e</sub> initially rising to a peak at 10.2\u2009°C, then falling to a trough at 20\u2009°C, 0.087 (95% confidence interval (CI): 0.025; 0.148) lower than the peak, and finally rising again (Fig.\xa0<a data-track="click" data-track-label="link" data-track-action="figure anchor" href="/articles/s41467-021-25914-8#Fig3">3</a>). AH has a similar non-linear shape with a maximum difference of 0.061 (95% CI: 0.011; 0.111) between the peak at 6.6\u2009g/m<sup>3</sup> and the trough at 11\u2009g/m<sup>3</sup>.</p>
+                           <div class="c-article-table" data-test="inline-table" data-container-section="table" id="table-2">
+                              <figure>
+                                 <figcaption class="c-article-table__figcaption"><b id="Tab2" data-test="table-caption">Table 2 Association between weather variables and <i>R</i><sub>e</sub>.</b></figcaption>
+                                 <div class="u-text-right u-hide-print">
+                                    <a class="c-article__pill-button" data-test="table-link" data-track="click" data-track-action="view table" data-track-label="button" rel="nofollow" href="/articles/s41467-021-25914-8/tables/2" aria-label="Full size table 2">
+                                       <span>Full size table</span>
+                                       <svg width="16" height="16" focusable="false" role="img" aria-hidden="true" class="u-icon">
+                                          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#global-icon-chevron-right"></use>
+                                       </svg>
+                                    </a>
+                                 </div>
+                              </figure>
+                           </div>
+                           <div class="c-article-section__figure js-c-reading-companion-figures-item" data-test="figure" data-container-section="figure" id="figure-3" data-title="Associations between weather variables, non-pharmaceutical interventions and the effective reproduction number.">
+                              <figure>
+                                 <figcaption><b id="Fig3" class="c-article-section__figure-caption" data-test="figure-caption-text">Fig. 3: Associations between weather variables, non-pharmaceutical interventions and the effective reproduction number.</b></figcaption>
+                                 <div class="c-article-section__figure-content">
+                                    <div class="c-article-section__figure-item">
+                                       <a class="c-article-section__figure-link" data-test="img-link" data-track="click" data-track-label="image" data-track-action="view figure" href="/articles/s41467-021-25914-8/figures/3" rel="nofollow">
+                                          <picture>
+                                             <source type="image/webp" srcset="//media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fs41467-021-25914-8/MediaObjects/41467_2021_25914_Fig3_HTML.png?as=webp"></source>
+                                             <img aria-describedby="Fig3" src="//media.springernature.com/lw685/springer-static/image/art%3A10.1038%2Fs41467-021-25914-8/MediaObjects/41467_2021_25914_Fig3_HTML.png" alt="figure3" loading="lazy" width="685" height="679" />
+                                          </picture>
+                                       </a>
+                                    </div>
+                                    <div class="c-article-section__figure-description" data-test="bottom-caption" id="figure-3-desc">
+                                       <p>Non-linear associations between (<b>a</b>) mean temperature (°C), (<b>b</b>) relative humidity (%), (<b>c</b>) absolute humidity (g/m<sup>3</sup>) and (<b>d</b>) OxCGRT Government Response Index and predicted <i>R</i><sub>e</sub> difference. Curves and their 95% confidence intervals show the predicted difference in <i>R</i><sub>e</sub> with respect to a reference value set to the value at the trough of the curve for meteorological variables (<b>a</b>–<b>c</b>), or for the OxCGRT Government Response Index\u2009=\u200950 (<b>d</b>). Two-sided Wald test <i>p</i> values and adjusted curves with 95% confidence intervals were obtained from multivariable meta-regression multilevel models adjusted by population (log scale), population density (log scale), GDP (log scale), % population &gt;65 years of age, PM<sub>2.5</sub> (μg/m<sup>3</sup>, log scale) and OxCGRT Government Response Index, with cities nested within countries. The marginal distribution along the <i>x</i>-axis represents the observed data for that covariate.</p>
+                                    </div>
+                                 </div>
+                                 <div class="u-text-right u-hide-print">
+                                    <a class="c-article__pill-button" data-test="article-link" data-track="click" data-track-label="button" data-track-action="view figure" href="/articles/s41467-021-25914-8/figures/3" data-track-dest="link:Figure3 Full size image" aria-label="Full size image figure 3" rel="nofollow">
+                                       <span>Full size image</span>
+                                       <svg width="16" height="16" focusable="false" role="img" aria-hidden="true" class="u-icon">
+                                          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#global-icon-chevron-right"></use>
+                                       </svg>
+                                    </a>
+                                 </div>
+                              </figure>
+                           </div>
+                           <h3 class="c-article__sub-heading" id="Sec5">The effect of NPIs on <i>R</i>\n                           <sub>e</sub>\n                        </h3>
+                           <p>Although we calculated <i>R</i><sub>e</sub> over a time window in which the OxCGRT Government Response Index, lagged by 10 days, had not yet reached 70, we included the value of the lagged OxCGRT Government Response Index at the end of the city-specific window in the model, to control for residual confounding. Despite being capped at 70, the OxCGRT Government Response Index had a strong association with the reproduction number (<i>p</i>\u2009&lt;\u20090.0001) (Supplementary Table\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">4</a>), explaining 13.8% of its variability (Fig.\xa0<a data-track="click" data-track-label="link" data-track-action="figure anchor" href="/articles/s41467-021-25914-8#Fig3">3</a> and Supplementary Table\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">4</a>, Models D1–D7) with an estimated reduction of <i>R</i><sub>e</sub> equal to 0.285 (95% CI: 0.223; 0.347) when levels of the Government Response Index increase from 21 (5th percentile) to 66 (95th percentile). Mean temperature explained 2.4% and AH 2.0% of the variation in <i>R</i><sub>e</sub>, and the five city-level characteristics explained 1.4% of the variability of the reproduction number (Supplementary Table\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">4</a>, Models D1–D8).</p>
+                           <h3 class="c-article__sub-heading" id="Sec6">Sensitivity analyses</h3>
+                           <p>We performed several sensitivity analyses to evaluate the robustness of the results considering alternative analytic or selection choices (see Supplementary Table\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">5</a>). The main results are stable when including a country-level fixed effect in the meta-regression model, i.e. considering the only within-country variation of covariates and outcome. Restricting the analysis to cities with weaker interventions (OxCGRT Government Response Index &lt;60) also gives similar results to the main analysis, apart from wind speed and precipitation also showing an association with <i>R</i><sub>e</sub>. The association between mean temperature and the effective reproduction number holds across all the sensitivity analyses, apart from in tropical and southern hemisphere cities, when stratifying by tropical and non-tropical or northern and southern hemisphere regions. However, this may be explained by the small number of cities and the resulting low power in the tropical and southern hemisphere sub-group. The association between AH and the effective reproduction number is somewhat less robust with no association observed when excluding tropical or southern hemisphere cities, when excluding China and Brazil (countries with earlier and later observation periods) and when considering meteorological variables lagged by 10 days. Excluding the ten cities with <i>R</i><sub>e</sub>\u2009&lt;\u20091 shows a tendency of an increased <i>R</i><sub>e</sub> for cities with low RH (<i>p</i>\u2009=\u20090.009) and a lower <i>R</i><sub>e</sub> in cities with higher solar radiation at the surface (<i>p</i>\u2009=\u20090.047) (Supplementary Figure\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">5</a>). We observed similar overall tendencies to our main results when we did not control for the OxCGRT Government Response Index in our model, although the effect of temperature and AH was enhanced (Supplementary Figure\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">6</a>), and when considering meteorological variables lagged by 10 days (Supplementary Table\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">5</a>). We found no evidence of an interaction between mean temperature and RH categorised in two levels (≤65% and &gt;65%) using the median value of 65% as the category threshold (<i>p</i>\u2009=\u20090.428).</p>
+                        </div>
+                     </div>
+                  </section>
+                  <section data-title="Discussion">
+                     <div class="c-article-section" id="Sec7-section">
+                        <h2 class="c-article-section__title js-section-title js-c-reading-companion-sections-item" id="Sec7">Discussion</h2>
+                        <div class="c-article-section__content" id="Sec7-content">
+                           <p>We combined datasets of COVID-19 transmission with meteorological, demographic, socio-economic and intervention data for 409 cities in 26 countries across the world to estimate the association between meteorological factors and <i>R</i><sub>e</sub> in the early phase of the COVID-19 pandemic. We found evidence of a modest non-monotonic association of outdoor mean temperature and AH with early-phase<i>R</i><sub>e</sub>, after controlling for potential confounders, including NPIs. Temperature explained 2.4% and AH 2.0% of the variation in <i>R</i><sub>e</sub>, compared to 13.8% explained by the OxCGRT Government Response Index in the adjusted analysis. The associations of temperature and AH with <i>R</i><sub>e</sub> were not independent; the high correlation between them precluded control of one for the other. Overall, there was little evidence for any change in the <i>R</i><sub>e</sub> of COVID-19 associated with RH and no evidence for precipitation and wind speed.</p>
+                           <p>Associations between temperature, humidity and SARS-CoV-2 transmission might be explained by three mechanisms. First, like other viruses with a lipid envelope, SARS-CoV-2 has been found to be sensitive to temperature, humidity and solar radiation under laboratory conditions<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" title="Ratnesar-Shumate, S. et al. Simulated sunlight rapidly inactivates SARS-CoV-2 on surfaces. J. Infect. Dis. 222, 214–222 (2020)." href="#ref-CR21" id="ref-link-section-d7564002e4321">21</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" title="Schuit, M. et al. Airborne SARS-CoV-2 is rapidly inactivated by simulated sunlight. J. Infect. Dis. 222, 564–571 (2020)." href="#ref-CR22" id="ref-link-section-d7564002e4321_1">22</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" title="Biryukov, J. et al. Increasing temperature and relative humidity accelerates inactivation of SARS-CoV-2 on surfaces. mSphere 5, e00441–20 (2020)." href="#ref-CR23" id="ref-link-section-d7564002e4321_2">23</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" title="Chan, K.-H. et al. Factors affecting stability and infectivity of SARS-CoV-2. J. Hosp. Infect. 106, 226–231 (2020)." href="#ref-CR24" id="ref-link-section-d7564002e4321_3">24</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 25" title="Dabisch, P. et al. The influence of temperature, humidity, and simulated sunlight on the infectivity of SARS-CoV-2 in aerosols. Aerosol Sci. Technol. 55, 142–153 (2021)." href="/articles/s41467-021-25914-8#ref-CR25" id="ref-link-section-d7564002e4324">25</a></sup>, which affects its ability to survive on surfaces and in aerosols. The droplet behaviour in aerosols changes with different temperature and humidity levels. Low RH promotes the accumulation of aerosol particles (since evaporation leaves behind floating droplet nuclei) increasing the likelihood to be inhaled<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 26" title="Zhao, L., Qi, Y., Luzzatto-Fegiz, P., Cui, Y. &amp; Zhu, Y. COVID-19: effects of environmental conditions on the propagation of respiratory droplets. Nano Lett. 20, 7744–7750 (2020)." href="/articles/s41467-021-25914-8#ref-CR26" id="ref-link-section-d7564002e4328">26</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 27" title="Lowen, A. C., Mubareka, S., Steel, J. &amp; Palese, P. Influenza virus transmission is dependent on relative humidity and temperature. PLoS Pathog. 3, e151 (2007)." href="/articles/s41467-021-25914-8#ref-CR27" id="ref-link-section-d7564002e4331">27</a></sup>. Second, innate and adaptive immune response mechanisms have been shown to be modulated by seasonal changes. Lower levels of vitamin D, mediated by decreased ultraviolet B radiation exposure during winter might lead to impaired antiviral innate immune defences<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" title="Cannell, J. J. et al. Epidemic influenza and vitamin D. Epidemiol. Infect. 134, 1129–1140 (2006)." href="#ref-CR28" id="ref-link-section-d7564002e4335">28</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" title="Grant, W. B. et al. Evidence that vitamin D supplementation could reduce risk of influenza and COVID-19 infections and deaths. Nutrients 12, 988 (2020)." href="#ref-CR29" id="ref-link-section-d7564002e4335_1">29</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 30" title="Tamerius, J. et al. Global influenza seasonality: reconciling patterns across temperate and tropical regions. Environ. Health Perspect. 119, 439–445 (2011)." href="/articles/s41467-021-25914-8#ref-CR30" id="ref-link-section-d7564002e4338">30</a></sup>. Breathing dry air can impair mucociliary clearance, reducing the ability of cilia cells to secrete mucus and remove viral particles (innate immune response)<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 27" title="Lowen, A. C., Mubareka, S., Steel, J. &amp; Palese, P. Influenza virus transmission is dependent on relative humidity and temperature. PLoS Pathog. 3, e151 (2007)." href="/articles/s41467-021-25914-8#ref-CR27" id="ref-link-section-d7564002e4342">27</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 31" title="Sun, Z., Thilakavathy, K., Kumar, S. S., He, G. &amp; Liu, S. V. Potential factors influencing repeated SARS outbreaks in China. Int. J. Environ. Res. Public. Health 17, 1633 (2020)." href="/articles/s41467-021-25914-8#ref-CR31" id="ref-link-section-d7564002e4345">31</a></sup>. Interferon-stimulated genes, usually inducing an antiviral state as part of the innate immune response have been found to be impaired at low RH<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 32" title="Kudo, E. et al. Low ambient humidity impairs barrier function and innate resistance against influenza infection. Proc. Natl Acad. Sci. USA 116, 10905–10910 (2019)." href="/articles/s41467-021-25914-8#ref-CR32" id="ref-link-section-d7564002e4349">32</a></sup>. High temperatures have been shown to hinder virus-specific CD8<sup>+</sup> T cell responses and antibody production (adaptive immune system)<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 33" title="Moriyama, M. &amp; Ichinohe, T. High ambient temperature dampens adaptive immune responses to influenza A virus infection. Proc. Natl Acad. Sci. USA 116, 3118–3125 (2019)." href="/articles/s41467-021-25914-8#ref-CR33" id="ref-link-section-d7564002e4356">33</a></sup>. Third, human mobility, contact patterns and time spent indoors are affected by weather conditions<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 34" title="Fares, A. Factors influencing the seasonal patterns of infectious diseases. Int. J. Prev. Med. 4, 128–132 (2013)." href="/articles/s41467-021-25914-8#ref-CR34" id="ref-link-section-d7564002e4360">34</a></sup>. Very hot and very cold conditions can lead to more time spent in enclosed spaces, which might increase the likelihood of SARS-CoV-2 transmission.</p>
+                           <p>Findings from this study are only partly consistent with findings from other global studies using statistical approaches to investigate meteorological effects on COVID-19 transmission. Meyer et al.<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 9" title="Meyer, A., Sadler, R., Faverjon, C., Cameron, A. R. &amp; Bannister-Tyrrell, M. Evidence that higher temperatures are associated with a marginally lower incidence of COVID-19 cases. Front. Public Health 8, 367 (2020)." href="/articles/s41467-021-25914-8#ref-CR9" id="ref-link-section-d7564002e4367">9</a></sup> found that mean temperature had a modest negative association with COVID-19 incidence for temperatures above −15\u2009°C based on a dataset of 100 countries, after controlling for surveillance capacity, time since first reported case, population density and median population age, whereas RH had a negative non-significant association with case incidence. Jüni et al.<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 13" title="Jüni, P. et al. Impact of climate and public health interventions on the COVID-19 pandemic: a prospective cohort study. Can. Med. Assoc. J. 192, E566–E573 (2020)." href="/articles/s41467-021-25914-8#ref-CR13" id="ref-link-section-d7564002e4371">13</a></sup> covering 144 geopolitical areas showed that temperature and humidity measures were not significantly associated with epidemic growth while significant associations were found for restrictions of mass gatherings, school closures and measures of social distancing, which are consistent with our findings of a stronger impact of the OxCGRT Government Response Index compared to climatic conditions. Wu et al.<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 35" title="Wu, Y. et al. Effects of temperature and humidity on the daily new cases and new deaths of COVID-19 in 166 countries. Sci. Total Environ. 729, 139051 (2020)." href="/articles/s41467-021-25914-8#ref-CR35" id="ref-link-section-d7564002e4375">35</a></sup> incorporating data from 166 countries found that a 1\u2009°C increase in temperature and RH was associated with a 3% and 0.85% decrease in daily new cases, respectively, after controlling for wind speed, median population age, Global Health Index, Human Development Index and population density. Interestingly, non-linear associations between mean daily temperature and the instantaneous reproduction number (<i>R</i><sub>t</sub>) in the United States of America were found in a study by Rubin et al.<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 12" title="Rubin, D. et al. Association of social distancing, population density, and temperature with the instantaneous reproduction number of SARS-CoV-2 in counties across the United States. JAMA Netw. Open 3, e2016099 (2020)." href="/articles/s41467-021-25914-8#ref-CR12" id="ref-link-section-d7564002e4383">12</a></sup> with <i>R</i><sub>t</sub> decreasing to a minimum as temperatures rose to 11\u2009°C, increasing between 11 and 20\u2009°C and then declining again at temperatures &gt;20\u2009°C. The shape of the association may be influenced by the indirect effect of weather in varying the likelihood of social interactions, e.g. at higher temperatures people may congregate in public cities, such as beaches and festivals<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 12" title="Rubin, D. et al. Association of social distancing, population density, and temperature with the instantaneous reproduction number of SARS-CoV-2 in counties across the United States. JAMA Netw. Open 3, e2016099 (2020)." href="/articles/s41467-021-25914-8#ref-CR12" id="ref-link-section-d7564002e4392">12</a></sup>, while colder temperatures could limit social activities, such as sporting events<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 34" title="Fares, A. Factors influencing the seasonal patterns of infectious diseases. Int. J. Prev. Med. 4, 128–132 (2013)." href="/articles/s41467-021-25914-8#ref-CR34" id="ref-link-section-d7564002e4396">34</a></sup>. Runkle et al.<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 11" title="Runkle, J. D. et al. Short-term effects of specific humidity and temperature on COVID-19 morbidity in select US cities. Sci. Total Environ. 740, 140093 (2020)." href="/articles/s41467-021-25914-8#ref-CR11" id="ref-link-section-d7564002e4400">11</a></sup> concluded from varying longitudinal associations in four cities that specific humidity in the range of 6–9\u2009g/kg (i.e. AH range of 7.6–11.4\u2009g/m<sup>3</sup>) was a significant predictor of the COVID-19 growth rate, in line with our findings.</p>
+                           <p>Unclear and inconsistent findings related to temperature and humidity may be due to methodological challenges and data limitations. Similar methodological challenges were highlighted when evaluating the association between air pollution and COVID-19 outbreaks<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 36" title="Villeneuve, P. J. &amp; Goldberg, M. S. Methodological considerations for epidemiological studies of air pollution and the SARS and COVID-19 coronavirus outbreaks. Environ. Health Perspect. 128, 095001 (2020)." href="/articles/s41467-021-25914-8#ref-CR36" id="ref-link-section-d7564002e4409">36</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 37" title="Heederik, D. J. J., Smit, L. A. M. &amp; Vermeulen, R. C. H. Go slow to go fast: a plea for sustained scientific rigour in air pollution research during the COVID-19 pandemic. Eur. Respir. J. 56, 2001361 (2020)." href="/articles/s41467-021-25914-8#ref-CR37" id="ref-link-section-d7564002e4412">37</a></sup>. The novelty of the virus, with less than a full annual cycle of data available in most places, makes it difficult to disentangle a seasonal signal or inter-annual trends from meteorological factors using time-series models<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 38" title="Imai, C., Armstrong, B., Chalabi, Z., Mangtani, P. &amp; Hashizume, M. Time series regression model for infectious disease and weather. Environ. Res. 142, 319–327 (2015)." href="/articles/s41467-021-25914-8#ref-CR38" id="ref-link-section-d7564002e4416">38</a></sup>. Moreover, different interventions (e.g. restrictions of mass gatherings, international travel and school closures) adopted by countries at different times after the onset of local outbreaks potentially confound the association between weather variables and COVID-19 spread. These challenges have led us to consider an ecological approach where we compared the outbreak curve early in the epidemic, minimising the confounding effect of NPIs. Despite this, we found a strong association of the OxCGRT Government Response Index with <i>R</i><sub>e</sub>, confirming the importance of interventions implemented early on in the epidemic in controlling COVID-19 dynamics<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 39" title="Liu, Y., Morgenstern, C., Kelly, J., Lowe, R. &amp; Jit, M. The impact of non-pharmaceutical interventions on SARS-CoV-2 transmission across 130 countries and territories. BMC Med. 19, 40 (2021)." href="/articles/s41467-021-25914-8#ref-CR39" id="ref-link-section-d7564002e4424">39</a></sup>.</p>
+                           <p>Comparing the early-phase outbreak curves in different countries is challenging given that countries have different case definitions, and early COVID-19 data only captured a small portion of cases, mainly hospitalised patients or individuals with severe symptoms. The estimated high proportion of asymptomatic cases compromises the use of COVID-19 case counts to estimate transmission dynamics<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 40" title="Li, R. et al. Substantial undocumented infection facilitates the rapid dissemination of novel coronavirus (SARS-CoV-2). Science 368, 489–493 (2020)." href="/articles/s41467-021-25914-8#ref-CR40" id="ref-link-section-d7564002e4432">40</a></sup>. We used an estimated response variable, i.e. the effective reproduction number, calculated accounting for reporting delays and other sources of uncertainty. The 20-day duration was chosen as a compromise between needing enough days for a more precise <i>R</i><sub>e</sub> estimation, while, at the same time, limiting the window to provide more constant weather, case ascertainment and <i>R</i><sub>e</sub> estimates within the window. A larger window would bias estimates in ways that cannot be readily adjusted for. Our meta-analysis approach accounts for the uncertainty in <i>R</i><sub>e</sub> estimates, which in turn reduces the level of certainty in the results. Further, 20 days is ~4 generations of infections, which, under most reporting scenarios, is sufficient to be confident about estimates in the level of transmission. We assume that within the 20-day time window, the case definition is constant within a city or country and <i>R</i><sub>e</sub> is not affected by differences in case definition between countries.</p>
+                           <p>A clear strength of this study is the use of an extensive dataset of 409 cities, representing 44.8% of all cumulative reported COVID-19 cases registered by 31 May 2020 in the John Hopkins University Coronavirus Resource Center. Our analysis covers all major climate zones across the globe, ranging from temperate, continental to tropical and dry climate settings. Another strength is our flexible methodological and statistical approach. We used multilevel meta-analytic models that take into account uncertainty of the response variable, i.e. the effective reproduction number. The model allowed for possible non-linearity of the exposures, and we adjusted for a selection of key socio-economic and demographic factors, as well as using a random effect to account for the country- and city-level differences. We chose covariates based on their potential impact on viral transmission that might confound the examined association of weather and COVID-19 dynamics. Indeed, population density leads to higher contact rates, potentially increasing the likelihood of transmission<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 41" title="Rocklöv, J. &amp; Sjödin, H. High population densities catalyse the spread of COVID-19. J. Travel Med. 27, taaa038 (2020)." href="/articles/s41467-021-25914-8#ref-CR41" id="ref-link-section-d7564002e4456">41</a></sup>. The age structure of a population is relevant given that elderly people were found to be more susceptible to infection and more likely to experience clinical symptoms of COVID-19 compared to younger age groups, increasing the likelihood of seeking medical care and getting tested<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 42" title="Davies, N. G. et al. Age-dependent effects in the transmission and control of COVID-19 epidemics. Nat. Med. 26, 1205–1211 (2020)." href="/articles/s41467-021-25914-8#ref-CR42" id="ref-link-section-d7564002e4460">42</a></sup>. Moreover, differences in contact patterns among different age groups can further affect the number of COVID-19 cases in each age group<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 42" title="Davies, N. G. et al. Age-dependent effects in the transmission and control of COVID-19 epidemics. Nat. Med. 26, 1205–1211 (2020)." href="/articles/s41467-021-25914-8#ref-CR42" id="ref-link-section-d7564002e4464">42</a></sup>. Socio-economic indicators, such as GDP per capita, are important to consider as more deprived populations might be at higher risk of infection due to potential conditions of overcrowded accommodation, inability to work from home or limited access to medical care<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 43" title="Patel, J. A. et al. Poverty, inequality and COVID-19: the forgotten vulnerable. Public Health 183, 110–111 (2020)." href="/articles/s41467-021-25914-8#ref-CR43" id="ref-link-section-d7564002e4468">43</a></sup>. Also, among air quality factors, a positive association between PM<sub>2.5</sub> and COVID-19 incidence and mortality has been reported<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 44" title="Borro, M. et al. Evidence-based considerations exploring relations between SARS-CoV-2 pandemic and air pollution: involvement of PM2.5-mediated up-regulation of the viral receptor ACE-2. Int. J. Environ. Res. Public. Health 17, 5573 (2020)." href="/articles/s41467-021-25914-8#ref-CR44" id="ref-link-section-d7564002e4475">44</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 45" title="Pozzer, A. et al. Regional and global contributions of air pollution to risk of death from COVID-19. Cardiovasc. Res. 116, 2247–2253 (2020)." href="/articles/s41467-021-25914-8#ref-CR45" id="ref-link-section-d7564002e4478">45</a></sup>.</p>
+                           <p>We investigated model uncertainties with several sensitivity analyses, e.g. excluding cities with <i>R</i>\u2009&lt;\u20091, excluding China and Brazil, cities in the southern hemisphere, cities with a latitude lower than 45°, and cities with an OxCGRT Government Response Index of more than 60. Previous studies compared cities within a country or considered large geographical units<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 13" title="Jüni, P. et al. Impact of climate and public health interventions on the COVID-19 pandemic: a prospective cohort study. Can. Med. Assoc. J. 192, E566–E573 (2020)." href="/articles/s41467-021-25914-8#ref-CR13" id="ref-link-section-d7564002e4488">13</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 35" title="Wu, Y. et al. Effects of temperature and humidity on the daily new cases and new deaths of COVID-19 in 166 countries. Sci. Total Environ. 729, 139051 (2020)." href="/articles/s41467-021-25914-8#ref-CR35" id="ref-link-section-d7564002e4491">35</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 46" title="Jiang, Y., Wu, X.-J. &amp; Guan, Y.-J. Effect of ambient air pollutants and meteorological variables on COVID-19 incidence. Infect. Control Hosp. Epidemiol. 41, 1011–1015 (2020)." href="/articles/s41467-021-25914-8#ref-CR46" id="ref-link-section-d7564002e4494">46</a></sup>, which could lead to a limited exposure range with narrow temperature and humidity variability reported during winter seasons, or high measurement errors for meteorological variables defined over large geographical units. We considered small area/city units distributed among 26 countries worldwide, allowing a good exposure range and minimising the measurement error of the exposures.</p>
+                           <p>Our study has several important limitations in addition to those already discussed. Cities in the northern hemisphere were overrepresented compared to southern hemisphere cities, which indicates that the findings might be more representative for cities in the global north. Our results need to be put into the context of complex uncertainties surrounding characteristics of the novel virus, such as incomplete knowledge on possible underlying mechanisms between weather conditions and the virus itself, the role of host immunity and the potential influence of weather-sensitive human behaviour, such as indoor crowding<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 47" title="Ryti, N. R. I., Korpelainen, A., Seppänen, O. &amp; Jaakkola, J. J. K. Paradoxical home temperatures during cold weather: a proof-of-concept study. Int. J. Biometeorol. 64, 2065–2076 (2020)." href="/articles/s41467-021-25914-8#ref-CR47" id="ref-link-section-d7564002e4501">47</a></sup>. However, AH was found to demonstrate the strongest indoor-to-outdoor correlation, indicating that outdoor AH measures could reflect indoor conditions<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 48" title="Marr, L. C., Tang, J. W., Van Mullekom, J. &amp; Lakdawala, S. S. Mechanistic insights into the effect of humidity on airborne influenza virus survival, transmission and incidence. J. R. Soc. Interface 16, 20180298 (2019)." href="/articles/s41467-021-25914-8#ref-CR48" id="ref-link-section-d7564002e4505">48</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 49" title="Nguyen, J. L., Schwartz, J. &amp; Dockery, D. W. The relationship between indoor and outdoor temperature, apparent temperature, relative humidity, and absolute humidity. Indoor Air 24, 103–112 (2014)." href="/articles/s41467-021-25914-8#ref-CR49" id="ref-link-section-d7564002e4508">49</a></sup>. Data limitations regarding the novel virus, including varying accuracy of COVID-19 case numbers, limited data availability across cities and temporal constraints of an incomplete seasonal cycle of SARS-CoV-2 contribute to the limitations of this analysis.</p>
+                           <p>Despite these limitations, the associations of weather with <i>R</i><sub>e</sub> in this study suggests that such effects are likely to be small compared to other drivers of transmission. NPIs had a stronger impact on variation in transmission between cities than meteorological variables. We found no weather conditions in which transmission is impeded if precautions (social distancing, mask use, etc.) are not taken. These results support the statement that, to date, COVID-19 interventions are critical regardless of meteorological conditions.</p>
+                        </div>
+                     </div>
+                  </section>
+                  <section data-title="Methods">
+                     <div class="c-article-section" id="Sec8-section">
+                        <h2 class="c-article-section__title js-section-title js-c-reading-companion-sections-item" id="Sec8">Methods</h2>
+                        <div class="c-article-section__content" id="Sec8-content">
+                           <h3 class="c-article__sub-heading" id="Sec9">Data</h3>
+                           <p>Data in this study were obtained from a well-established MCC Collaborative Research Network<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 50" title="Gasparrini, A. et al. Mortality risk attributable to high and low ambient temperature: a multicountry observational study. Lancet 386, 369–375 (2015)." href="/articles/s41467-021-25914-8#ref-CR50" id="ref-link-section-d7564002e4531">50</a></sup>. The current MCC network covers 750 locations (cities or regions) in 43 countries/regions. For this study, 26 countries provided a daily time series of COVID-19 cases for a total of 502 locations (cities or small regions). COVID-19 data were downloaded from a publicly available repository or obtained from health agencies (Supplementary Table\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">1</a>) and data management was performed using Microsoft Excel 2019. The time series from 1 January 2020 to 31 May 2020 comprises 2,771,137 COVID-19 cases, representing 44.8% of the cumulative cases registered by 31 May 2020 in the Johns Hopkins database (<a href="https://coronavirus.jhu.edu/">https://coronavirus.jhu.edu/</a>). Supplementary Table\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">1</a> shows the sources used for each country along with the definition of COVID-19 cases.</p>
+                           <p>To limit potential confounding by NPIs and temporal variation in case ascertainment, we selected a 10–20-day window early in the epidemic, starting after at least ten confirmed cases had occurred in a 10-day period, to reduce noise introduced by imported cases. We excluded days for which the OxCGRT Government Response Index exceeded 70, accepting reduced windows down to 10 days in length. The OxCGRT collates publicly available information on 18 indicators about governments’ policy responses to the COVID-19 pandemic (<a href="https://www.bsg.ox.ac.uk/research/research-projects/coronavirus-government-response-tracker">https://www.bsg.ox.ac.uk/research/research-projects/coronavirus-government-response-tracker</a>). These indicators are categorised as containment or closure policies (e.g. school and workplace closures, restrictions on gatherings and movement), economic policies (e.g. income support) or health policies (e.g. COVID-19 testing programmes). The OxCGRT Government Response Index aggregates these indicators into a single score between 0 and 100 and provides a measure of how many policies a government has enacted, and to what degree. We chose 70 as the maximum value of OxCGRT Government Response Index allowable as a compromise between limiting confounding by government interventions and including enough cities to enable estimation of the associations studied (see Supplementary text\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">1</a>). Applying these conditions/restrictions reduced our dataset to 409 cities or small regions in 26 countries with an observation period between 11 January 2020 and 28 April 2020.</p>
+                           <p>Most of the 409 cities are situated in the northern hemisphere (<i>n</i>\u2009=\u2009381), and in temperate (n\u2009=\u2009292) or continental (n\u2009=\u200965) climatic zones, with few cities located in tropical (<i>n</i>\u2009=\u200923) and dry (<i>n</i>\u2009=\u200929) climatic zones. The COVID-19 cases were observed in the early phase of the epidemics, ranging from the first week of February 2020 in China to mid-April 2020 in Brazil (Supplementary Figure\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">1</a>). This early epidemic phase is characterised in many countries (except Uruguay and Singapore) by a reproduction number &gt;1 (Table\xa0<a data-track="click" data-track-label="link" data-track-action="table anchor" href="/articles/s41467-021-25914-8#Tab1">1</a>).</p>
+                           <p>We estimated <i>R</i><sub>e</sub> for infections in the time window of interest using EpiNow2 1.3.2<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 18" title="Abbott, S., Hellewell, J., Munday, J., Thompson, R. &amp; Funk, S. EpiNow: estimate realtime case counts and time-varying epidemiological parameters. Zenodo &#xA;                  https://doi.org/10.5281/zenodo.3957489&#xA;                  &#xA;                 (2020)." href="/articles/s41467-021-25914-8#ref-CR18" id="ref-link-section-d7564002e4586">18</a></sup>. This R package implements a Bayesian latent variable method for estimating <i>R</i><sub>e</sub>, where infections at time <i>t</i> are estimated using the sum of previous infections, weighted by an uncertain, gamma-distributed, generation time probability mass function, and multiplied by an estimate of <i>R</i><sub>e</sub><sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 51" title="Abbott, S. et al. Estimating the time-varying reproduction number of SARS-CoV-2 using national and subnational case counts. Wellcome Open Res. 5, 112 (2020)." href="/articles/s41467-021-25914-8#ref-CR51" id="ref-link-section-d7564002e4601">51</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 52" title="Sherratt, K. et al. Exploring surveillance data biases when estimating the reproduction number: with insights into subpopulation transmission of Covid-19 in England. Philos. Trans. R. Soc. B 376, 20200283 (2021)." href="/articles/s41467-021-25914-8#ref-CR52" id="ref-link-section-d7564002e4604">52</a></sup>. Initial infections (prior to the first reported case) were estimated using a log-linear model with priors based on the observed growth in cases. Complete infection trajectories were then mapped to reported case counts by first convolving over the incubation period distribution and an estimated distribution representing the delay between symptom onset and case report (both assumed to be log-normal). Reporting noise was then added using a negative binomial observation model combined with a multiplicative day of the week effect (modelled using a simplex). <i>R</i><sub>e</sub> was considered to be piecewise constant with a breakpoint 3 days into the time window. The <i>R</i><sub>e</sub> estimate from the first 3 days of the window was discarded with the <i>R</i><sub>e</sub> estimate from the remainder of the window used in all analyses. Each region was fitted independently using Markov chain Monte Carlo. Four chains were used with a warmup of 1000 samples and 4000 samples post warmup. Convergence was assessed using the R hat diagnostic<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 53" title="Stan Development Team. RStan: The R interface to Stan (Stan Development Team, 2020)." href="/articles/s41467-021-25914-8#ref-CR53" id="ref-link-section-d7564002e4621">53</a></sup>.</p>
+                           <p>We used a gamma-distributed generation time with a mean of 3.6 days (standard deviation (SD) 0.7) and a SD of 3.1 days (SD 0.8)<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 54" title="Abbott, S. et al. Estimating the time-varying reproduction number of SARS-CoV-2 using national and subnational case counts. Wellcome Open Res. 5, 112 (2020)." href="/articles/s41467-021-25914-8#ref-CR54" id="ref-link-section-d7564002e4629">54</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 55" title="Ganyani, T. et al. Estimating the generation interval for coronavirus disease (COVID-19) based on symptom onset data, March 2020. Eurosurveillance 25, 2000257 (2020)." href="/articles/s41467-021-25914-8#ref-CR55" id="ref-link-section-d7564002e4632">55</a></sup>. This generation time was slightly shorter than the consensus estimate reported by Ferretti et al.<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 56" title="Ferretti, L. et al. The timing of COVID-19 transmission. Preprint at medRxiv &#xA;                  https://doi.org/10.1101/2020.09.04.20188516&#xA;                  &#xA;                 (2020)." href="/articles/s41467-021-25914-8#ref-CR56" id="ref-link-section-d7564002e4636">56</a></sup>, leading to our <i>R</i><sub>e</sub> estimates and subsequent effect sizes being conservative. We used a log-normally distributed prior for the incubation period with a mean of 5.2 days (SD 1.1) and SD of 1.52 days (SD 1.1)<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 57" title="Lauer, S. A. et al. The incubation period of Coronavirus Disease 2019 (COVID-19) from publicly reported confirmed cases: estimation and application. Ann. Intern. Med. 172, 577–582 (2020)." href="/articles/s41467-021-25914-8#ref-CR57" id="ref-link-section-d7564002e4644">57</a></sup>. The log-normal prior for the delay from symptom onset to case report was estimated globally using a subsampled Bayesian bootstrapping approach (with 100 subsamples each using 250 samples) using data from an international line list of cases. The resulting distribution had a mean of 6.4 days and a standard deviation (SD) of 17 days (or a log mean of 0.83 (SD 0.15) and a log SD 1.44 (SD 0.12). The subsampled bootstrap approach was used to incorporate both the temporal and spatial uncertainty in the reporting distribution as data specific to each setting and time point was not available.</p>
+                           <p>To define our exposures, we considered the following time series from the ERA5 dataset: 2\u2009m temperature, 2\u2009m dewpoint temperature, surface solar radiation downwards, precipitation, and 10\u2009m eastward (<i>u</i>) and northward (<i>v</i>) components of wind. These are published by the Copernicus Climate Change service on a regular latitude/longitude grid of 0.25° (~25\u2009km\u2009×\u200925\u2009km) in NetCDF format<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 19" title="Hersbach, H. et al. ERA5 Hourly Data on Single Levels from 1979 to Present (Copernicus Climate Change Service (C3S) Climate Data Store (CDS), 2018)." href="/articles/s41467-021-25914-8#ref-CR19" id="ref-link-section-d7564002e4657">19</a></sup>. The hourly 2\u2009m temperature, 2\u2009m dewpoint temperature and surface solar radiation downwards were averaged for each day to derive daily mean temperature, dewpoint temperature and surface solar radiation. From dewpoint temperature and the corresponding temperature (<i>T</i>; °C) we obtained RH (%) using the R ‘humidity’ 0.1.5 package<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 58" title="Jun, C. Calculate water vapor measures from temperature and dew point. &#xA;                  https://github.com/caijun/humidity&#xA;                  &#xA;                 (2019)." href="/articles/s41467-021-25914-8#ref-CR58" id="ref-link-section-d7564002e4664">58</a></sup>. The following formula was used to calculate AH (g/m<sup>3</sup>), which represents the mass of water vapour in the air mixture<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 59" title="Shi, P. et al. The impact of temperature and absolute humidity on the coronavirus disease 2019 (COVID-19) outbreak - evidence from China. Preprint at medRxiv &#xA;                  https://doi.org/10.1101/2020.03.22.20038919&#xA;                  &#xA;                 (2020)." href="/articles/s41467-021-25914-8#ref-CR59" id="ref-link-section-d7564002e4671">59</a></sup>:</p>
+                           <div id="Equa" class="c-article-equation">
+                              <div class="c-article-equation__content"><span class="mathjax-tex">$${{{{{\\mathrm{AH}}}}}}=(6.112\\times {e}^{(17.67\\times T)/(T+243.5)}\\times 2.1674\\times {{{{{\\mathrm{RH}}}}}})/(273.15+T).$$</span></div>
+                           </div>
+                           <p>The hourly 10\u2009m <i>u</i> and <i>v</i> components of wind were averaged for each day, and the daily average <i>u</i> and <i>v</i> components were used to compute the wind speed using the formula wind speed\u2009=\u2009sqrt(<i>u</i><sup>2</sup>\u2009+\u2009<i>v</i><sup>2</sup>). Hourly precipitation data were summed to derive daily totals. The daily variables were calculated for each 25\u2009km<sup>2</sup> grid cell and assigned to a city if the city centroid fell within the grid cell.</p>
+                           <p>Mean temperature (and other meteorological variables, Supplementary Table\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">3</a>) observed during the city-specific time window reflect the late winter/early spring observation period in cities situated in the northern hemisphere and in temperate or continental climatic zones. We found a high correlation between mean temperature and AH (Supplementary Figure\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">2</a>). Socio-economic and demographic characteristics were extracted from the OECD Regional and Metropolitan database<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 60" title="OECD. OECD regions at a glance 2016. &#xA;                  https://doi.org/10.1787/reg_glance-2016-en&#xA;                  &#xA;                 (2016)." href="/articles/s41467-021-25914-8#ref-CR60" id="ref-link-section-d7564002e4819">60</a></sup> and Worldcities database<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 61" title="Simplemaps. World cities database. &#xA;                  https://simplemaps.com/data/world-cities&#xA;                  &#xA;                 (2016)." href="/articles/s41467-021-25914-8#ref-CR61" id="ref-link-section-d7564002e4823">61</a></sup> (Supplementary Table\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">2</a>). We selected, a priori, the following set of confounders: total population, population density, % elderly population (&gt;65 years) and GDP (per capita). Pollution data (PM<sub>2.5</sub>) for the observation period (10–20 days) was obtained from the Copernicus Atmosphere Monitoring Service global near-real-time service<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" title="Christophe, Y. et al. Validation Report of the CAMS Near-Real-Time Global Atmospheric Composition Service: Period March–May 2019. Copernicus Atmosphere Monitoring Service (CAMS) Report (2019)." href="#ref-CR62" id="ref-link-section-d7564002e4833">62</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" title="Morcrette, J.-J. et al. Aerosol analysis and forecast in the European Centre for medium-range weather forecasts integrated forecast system: forward modeling. J. Geophys. Res. Atmos. 114, &#xA;                  https://doi.org/10.1029/2008JD011235&#xA;                  &#xA;                 (2009)." href="#ref-CR63" id="ref-link-section-d7564002e4833_1">63</a>,<a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 64" title="Benedetti, A. et al. Aerosol analysis and forecast in the European centre for medium-range weather forecasts integrated forecast system: 2. Data assimilation. J. Geophys. Res. Atmos. 114, &#xA;                  https://doi.org/10.1029/2008JD011115&#xA;                  &#xA;                 (2009)." href="/articles/s41467-021-25914-8#ref-CR64" id="ref-link-section-d7564002e4836">64</a></sup>. This product provides hourly modelled values of surface PM<sub>2.5</sub> (μg/m<sup>3</sup>) at a 0.4\u2009×\u20090.4 arc degrees grid cell resolution. The hourly time series were averaged over the observation period and linked to the city using the city centroid coordinates. Cities vary in terms of socio-demographic characteristics (Supplementary Table\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">3</a>). The correlation between socio-demographic characteristics is shown in Supplementary Figure\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">3</a> and the correlation between meteorological variables, OxCGRT Government Response Index, day of the year and <i>R</i><sub>e</sub> in Supplementary Figure\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">4</a>. To account for differences in NPIs we used the OxCGRT Government Response Index<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 65" title="Hale, T. et al. Variation in Government Responses to COVID-19. Blavatnik School of Government Working Paper. &#xA;                  www.bsg.ox.ac.uk/covidtracker&#xA;                  &#xA;                 (2021)." href="/articles/s41467-021-25914-8#ref-CR65" id="ref-link-section-d7564002e4858">65</a></sup>. In this study, we considered the 10 days lagged value of the OxCGRT Government Response Index, and for each city, we assigned the index on the last day of the specified window for each city<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 39" title="Liu, Y., Morgenstern, C., Kelly, J., Lowe, R. &amp; Jit, M. The impact of non-pharmaceutical interventions on SARS-CoV-2 transmission across 130 countries and territories. BMC Med. 19, 40 (2021)." href="/articles/s41467-021-25914-8#ref-CR39" id="ref-link-section-d7564002e4862">39</a></sup>. Note, in our analysis, meteorological variables and socio-demographic covariates were collated and summarised at the city level, while the COVID-19 time series were defined at the smallest administrative level containing the city. We only included cities for which the COVID-19 time series were available for an area in which most of the population resided in that city. We, therefore, refer to our unit of analysis as a city.</p>
+                           <h3 class="c-article__sub-heading" id="Sec10">Statistical analysis</h3>
+                           <p>For descriptive purposes, the following statistics (mean, standard deviation and range) were calculated for meteorological variables (mean temperature, AH, RH, surface solar radiation, wind speed, total precipitation) and covariates considered in this study (total population, population density, % elderly population (&gt;65 years), GDP (per capita), PM<sub>2.5</sub>, OxCGRT Government Response Index). We also calculated the correlation (Pearson coefficient) among meteorological variables and among covariates.</p>
+                           <p>The association between city-level covariates and climatic variables with the effective reproduction number were evaluated using multilevel meta-regression models with two levels (cities nested within countries)<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 20" title="Sera, F., Armstrong, B., Blangiardo, M. &amp; Gasparrini, A. An extended mixed‐effects framework for meta‐analysis. Stat. Med. 38, 5429–5444 (2019)." href="/articles/s41467-021-25914-8#ref-CR20" id="ref-link-section-d7564002e4879">20</a></sup> using the R ‘mixmeta’ 1.1.0 package. The inclusion of country as a random effect allowed the model to account for country differences (e.g. data reporting) with efficient use of the within- and between-country information. Moreover, the meta-regression models allowed us to consider the precision of the <i>R</i><sub>e</sub> estimates, as estimated by its variance, giving less weight to more imprecise estimates for shorter time windows.</p>
+                           <p>Firstly, we used two-level meta-regression models to evaluate the possible non-linear association between each meteorological variable and the reproduction number <i>R</i><sub>e</sub>. We considered possible non-linearity in the association with <i>R</i><sub>e</sub> using a natural spline parameterisation of the meteorological variables with a variable number of internal knots from 0 (linear term) to 5, placed at respective percentiles of the variable. We compare the models with different non-linear parameterisations of the meteorological variable using the Akaike Information Criteria (AIC), choosing models with the lowest AIC.</p>
+                           <p>We fitted the following two-level random-effects meta-regression models with cities nested within countries and an increasing number of predictors; Model A with two random effects (cities and countries) and the intercepts, Model B including the OxCGRT Government Response Index, Model C considering also total population, density, GDP, % population older than 65 years, and PM<sub>2.5</sub> (total population, density, GDP and PM<sub>2.5</sub> were log-transformed due to the skewness of their distribution).</p>
+                           <p>Then for each meteorological variable, we fitted two-level meta-regression models (D1–D6) with the meteorological variable as exposure and total population, density, GDP, % population older than 65 years, PM<sub>2.5</sub> and the OxCGRT Government Response Index as covariates. We considered non-linearity in the association with <i>R</i><sub>e</sub> using a natural spline parameterisation of the climatic variables with the number of internal knots as determined in the univariate analysis. The coefficients of the natural spline parameterisation of the meteorological variable were used to derive the plot of the association between the meteorological variable and <i>R</i><sub>e</sub> in the 5–95th percentile of the meteorological variable distribution (Fig.\xa0<a data-track="click" data-track-label="link" data-track-action="figure anchor" href="/articles/s41467-021-25914-8#Fig3">3</a> and Supplementary Figures\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">5</a> and <a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">6</a>). The coefficients of the natural spline parameterisation of the meteorological variable were also used to test the association between the meteorological variable and <i>R</i><sub>e</sub> using the multivariate Wald test. All the tests were two-sided. Given the small number of pre-defined exposures variables, no adjustment was made for multiple comparisons.</p>
+                           <p>We quantified heterogeneity between cities with standard measures of <i>I</i><sup>2</sup>\u2009<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 66" title="Higgins, J. P. T. &amp; Thompson, S. G. Quantifying heterogeneity in a meta-analysis. Stat. Med. 21, 1539–1558 (2002)." href="/articles/s41467-021-25914-8#ref-CR66" id="ref-link-section-d7564002e4940">66</a></sup>. These measures are estimated once from a meta-regression model without meta-predictors (Model A) and once from the meta-regression models (Models B, C and D1–D6) to assess the reduction in residual heterogeneity provided by the different set of predictors. For each model, we calculated the likelihood ratio test (<i>R</i><sub>LR</sub><sup>2</sup>) statistic<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 67" title="Kramer, M. R2 statistics for mixed models. Conf. Appl. Stat. Agric. &#xA;                  https://doi.org/10.4148/2475-7772.1142&#xA;                  &#xA;                 (2005)." href="/articles/s41467-021-25914-8#ref-CR67" id="ref-link-section-d7564002e4949">67</a></sup>. <i>R</i><sub>LR</sub><sup>2</sup> is calculated as 1\u2009−\u2009exp(−2/409\u2009×\u2009(log\u2009Lik<sub>m</sub>\u2009−\u2009log\u2009Lik<sub>0</sub>), where log\u2009Lik<sub>m</sub> is the log-likelihood of the model of interest and log\u2009Lik<sub>0</sub> is the log-likelihood from a null model including only city and country random effect (i.e. Model A). For each meteorological variable, we calculated the difference in the likelihood ratio test <i>R</i><sup>2</sup> (<i>R</i><sub>LR</sub><sup>2</sup>) with respect to Model C (including random effects, OxCGRT Government Response Index and city-level covariates). For OxCGRT and city-level covariates, the <i>R</i><sub>LR</sub><sup>2</sup> represents the reduction in <i>R</i><sub>LR</sub><sup>2</sup> when dropping OxCGRT or city-level covariates from Model D1 with temperature and all other terms (i.e. random effects, OxCGRT and city-level covariates).</p>
+                           <h3 class="c-article__sub-heading" id="Sec11">Reporting summary</h3>
+                           <p>Further information on research design is available in the\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM3">Nature Research Reporting Summary</a> linked to this article.</p>
+                        </div>
+                     </div>
+                  </section>
+                  \n            \n\n
+                  <section data-title="Data availability">
+                     <div class="c-article-section" id="data-availability-section">
+                        <h2 class="c-article-section__title js-section-title js-c-reading-companion-sections-item" id="data-availability">Data availability</h2>
+                        <div class="c-article-section__content" id="data-availability-content">
+                           \n              \n
+                           <p>COVID-19 data were downloaded from publicly available repositories or obtained from health agencies (Supplementary Table\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">1</a>). COVID-19 data for Australia, Brazil, Canada, Chile, China, Czech Republic, Estonia, Finland, Germany, Italy, Kuwait, Mexico, Norway, Peru, Philippines, Romania, South Korea, Spain, United Kingdom, United States and Vietnam are publicly available. COVID-19 data for Japan and Singapore are available upon request. COVID-19 Data for France, Switzerland and Uruguay were obtained by a specific request to health agencies and are not publicly available.</p>
+                           \n
+                           <p>Meteorological variables (mean temperature, dewpoint temperature, solar radiation, wind components and precipitation) were derived from ERA5 reanalysis product ‘<a href="https://cds.climate.copernicus.eu/cdsapp#!/search?type=dataset">https://cds.climate.copernicus.eu/cdsapp#!/search?type=dataset</a>’.</p>
+                           \n
+                           <p>Pollution levels (PM2.5) was derived from CAMS near real time ‘<a href="https://apps.ecmwf.int/datasets/data/cams-nrealtime/levtype=sfc/">https://apps.ecmwf.int/datasets/data/cams-nrealtime/levtype=sfc/</a>’.</p>
+                           \n
+                           <p>The OxCGRT Government Response Index was downloaded from the public repository: <a href="https://github.com/OxCGRT/covid-policy-tracker/raw/master/data/OxCGRT_latest.csv">https://github.com/OxCGRT/covid-policy-tracker/raw/master/data/OxCGRT_latest.csv</a> (downloaded 3 August 2020).</p>
+                           \n
+                           <p>Socio-economic and demographic characteristics were extracted from the OECD Regional and Metropolitan database ‘<a href="https://www.oecd.org/regional/regional-policy/regionalstatisticsandindicators.htm">https://www.oecd.org/regional/regional-policy/regionalstatisticsandindicators.htm</a>’ and Worldcities database.</p>
+                           \n
+                           <p>Data were processed and harmonised at the city level. The city-level data used in the main and supplementary analysis of the paper are available in the GitHub directory: <a href="https://github.com/fsera/COVIDWeather/">https://github.com/fsera/COVIDWeather/</a><sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 68" title="Sera, F., Abbott, S. &amp; Royé. Data and code to replicate the analysis of the paper. ‘A cross-sectional analysis of meteorological factors and SARS-CoV-2 transmission in 409 cities across 26 countries’. &#xA;                  https://doi.org/10.5281/zenodo.5215842&#xA;                  &#xA;                 (2021)." href="/articles/s41467-021-25914-8#ref-CR68" id="ref-link-section-d7564002e5115">68</a></sup>.</p>
+                           \n
+                        </div>
+                     </div>
+                  </section>
+                  <section data-title="Code availability">
+                     <div class="c-article-section" id="code-availability-section">
+                        <h2 class="c-article-section__title js-section-title js-c-reading-companion-sections-item" id="code-availability">Code availability</h2>
+                        <div class="c-article-section__content" id="code-availability-content">
+                           \n              \n
+                           <p>The code developed in the study to perform the city-level main analysis is available in the following <a href="https://github.com/fsera/COVIDWeather">GitHub</a> repository<sup><a data-track="click" data-track-action="reference anchor" data-track-label="link" data-test="citation-ref" aria-label="Reference 68" title="Sera, F., Abbott, S. &amp; Royé. Data and code to replicate the analysis of the paper. ‘A cross-sectional analysis of meteorological factors and SARS-CoV-2 transmission in 409 cities across 26 countries’. &#xA;                  https://doi.org/10.5281/zenodo.5215842&#xA;                  &#xA;                 (2021)." href="/articles/s41467-021-25914-8#ref-CR68" id="ref-link-section-d7564002e5134">68</a></sup>.</p>
+                           \n
+                           <p>For each meteorological variable, the effect size was calculated using predicted curves from multivariable meta-regression multilevel models. We calculated the difference in the likelihood ratio test <i>R</i><sup>2</sup> (<i>R</i><sub>LR</sub><sup>2</sup>) with respect to a model including random effects, OxCGRT Government Response Index, and city-level covariates (Model C, Supplementary Table\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">4</a>). <i>R</i><sub>LR</sub><sup>2</sup> is calculated as 1\u2009−\u2009exp(−2/409\u2009×\u2009(log\u2009Lik<sub>m</sub>\u2009−\u2009log\u2009Lik<sub>0</sub>), where log\u2009Lik<sub>m</sub> is the log-likelihood of the model of interest and log\u2009Lik<sub>0</sub> is the log-likelihood from a null model including only city and country random effect (i.e., Model A, Supplementary Table\xa0<a data-track="click" data-track-label="link" data-track-action="supplementary material anchor" href="/articles/s41467-021-25914-8#MOESM1">4</a>). For OxCGRT, the <i>R</i><sub>LR</sub><sup>2</sup> represents the reduction in <i>R</i><sub>LR</sub><sup>2</sup> when dropping OxCGRT from the model with temperature and all other terms (i.e., random-effects and city-level covariates).</p>
+                           \n
+                        </div>
+                     </div>
+                  </section>
+                  <div id="MagazineFulltextArticleBodySuffix">
+                     <section aria-labelledby="Bib1" data-title="References">
+                        <div class="c-article-section" id="Bib1-section">
+                           <h2 class="c-article-section__title js-section-title js-c-reading-companion-sections-item" id="Bib1">References</h2>
+                           <div class="c-article-section__content" id="Bib1-content">
+                              <div data-container-section="references">
+                                 <ol class="c-article-references">
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">1.</span>
+                                       <p class="c-article-references__text" id="ref-CR1">Moriyama, M., Hugentobler, W. J. &amp; Iwasaki, A. Seasonality of respiratory viral infections.<i>Annu. Rev. Virol.</i> <b>7</b>, 83–101 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXltlCqur8%253D" aria-label="CAS reference 1">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1146%2Fannurev-virology-012420-022445" aria-label="Article reference 1">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 1" href="http://scholar.google.com/scholar_lookup?&amp;title=Seasonality%20of%20respiratory%20viral%20infections.&amp;journal=Annu.%20Rev.%20Virol.&amp;volume=7&amp;pages=83-101&amp;publication_year=2020&amp;author=Moriyama%2CM&amp;author=Hugentobler%2CWJ&amp;author=Iwasaki%2CA">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">2.</span>
+                                       <p class="c-article-references__text" id="ref-CR2">Lowen, A. C. &amp; Steel, J. Roles of humidity and temperature in shaping influenza seasonality. <i>J. Virol.</i> <b>88</b>, 7692–7695 (2014).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BC2cXhsVKjtbbK" aria-label="CAS reference 2">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=24789791" aria-label="PubMed reference 2" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4097773" aria-label="PubMed Central reference 2" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1128%2FJVI.03544-13" aria-label="Article reference 2">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 2" href="http://scholar.google.com/scholar_lookup?&amp;title=Roles%20of%20humidity%20and%20temperature%20in%20shaping%20influenza%20seasonality&amp;journal=J.%20Virol.&amp;volume=88&amp;pages=7692-7695&amp;publication_year=2014&amp;author=Lowen%2CAC&amp;author=Steel%2CJ">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">3.</span>
+                                       <p class="c-article-references__text" id="ref-CR3">Carlson, C. J., Gomez, A. C. R., Bansal, S. &amp; Ryan, S. J. Misconceptions about weather and seasonality must not misguide COVID-19 response. <i>Nat. Commun.</i> <b>11</b>, 4312 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://adsabs.harvard.edu/cgi-bin/nph-data_query?link_type=ABSTRACT&amp;bibcode=2020NatCo..11.4312C" aria-label="ADS reference 3">ADS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXhslWqtbzL" aria-label="CAS reference 3">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32855406" aria-label="PubMed reference 3" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7452887" aria-label="PubMed Central reference 3" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1038%2Fs41467-020-18150-z" aria-label="Article reference 3">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 3" href="http://scholar.google.com/scholar_lookup?&amp;title=Misconceptions%20about%20weather%20and%20seasonality%20must%20not%20misguide%20COVID-19%20response&amp;journal=Nat.%20Commun.&amp;volume=11&amp;publication_year=2020&amp;author=Carlson%2CCJ&amp;author=Gomez%2CACR&amp;author=Bansal%2CS&amp;author=Ryan%2CSJ">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">4.</span>
+                                       <p class="c-article-references__text" id="ref-CR4">Baker, R. E., Yang, W., Vecchi, G. A., Metcalf, C. J. E. &amp; Grenfell, B. T. Susceptible supply limits the role of climate in the early SARS-CoV-2 pandemic. <i>Science</i> <b>369</b>, 315–319 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://adsabs.harvard.edu/cgi-bin/nph-data_query?link_type=ABSTRACT&amp;bibcode=2020Sci...369..315B" aria-label="ADS reference 4">ADS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXhsVSjtLbL" aria-label="CAS reference 4">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32423996" aria-label="PubMed reference 4" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7243362" aria-label="PubMed Central reference 4" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1126%2Fscience.abc2535" aria-label="Article reference 4">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 4" href="http://scholar.google.com/scholar_lookup?&amp;title=Susceptible%20supply%20limits%20the%20role%20of%20climate%20in%20the%20early%20SARS-CoV-2%20pandemic&amp;journal=Science&amp;volume=369&amp;pages=315-319&amp;publication_year=2020&amp;author=Baker%2CRE&amp;author=Yang%2CW&amp;author=Vecchi%2CGA&amp;author=Metcalf%2CCJE&amp;author=Grenfell%2CBT">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">5.</span>
+                                       <p class="c-article-references__text" id="ref-CR5">O’Reilly, K. M. et al. Effective transmission across the globe: the role of climate in COVID-19 mitigation strategies. <i>Lancet Planet. Health</i> <b>4</b>, e172 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32389182" aria-label="PubMed reference 5" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7202845" aria-label="PubMed Central reference 5" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1016%2FS2542-5196%2820%2930106-6" aria-label="Article reference 5">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 5" href="http://scholar.google.com/scholar_lookup?&amp;title=Effective%20transmission%20across%20the%20globe%3A%20the%20role%20of%20climate%20in%20COVID-19%20mitigation%20strategies&amp;journal=Lancet%20Planet.%20Health&amp;volume=4&amp;publication_year=2020&amp;author=O%E2%80%99Reilly%2CKM">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">6.</span>
+                                       <p class="c-article-references__text" id="ref-CR6">Zeka, A. et al. Responding to COVID-19 requires strong epidemiological evidence of environmental and societal determining factors. <i>Lancet Planet. Health</i> <b>4</b>, e375–e376 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32918880" aria-label="PubMed reference 6" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7480994" aria-label="PubMed Central reference 6" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1016%2FS2542-5196%2820%2930169-8" aria-label="Article reference 6">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 6" href="http://scholar.google.com/scholar_lookup?&amp;title=Responding%20to%20COVID-19%20requires%20strong%20epidemiological%20evidence%20of%20environmental%20and%20societal%20determining%20factors&amp;journal=Lancet%20Planet.%20Health&amp;volume=4&amp;pages=e375-e376&amp;publication_year=2020&amp;author=Zeka%2CA">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">7.</span>
+                                       <p class="c-article-references__text" id="ref-CR7">Adhikari, A. &amp; Yin, J. Short-term effects of ambient ozone, PM2.5, and meteorological factors on COVID-19 confirmed cases and deaths in Queens, New York. <i>Int. J. Environ. Res. Public Health</i> <b>17</b>, 4047 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXhvFOlt7zI" aria-label="CAS reference 7">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7312351" aria-label="PubMed Central reference 7" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.3390%2Fijerph17114047" aria-label="Article reference 7">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=7312351" aria-label="PubMed reference 7" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 7" href="http://scholar.google.com/scholar_lookup?&amp;title=Short-term%20effects%20of%20ambient%20ozone%2C%20PM2.5%2C%20and%20meteorological%20factors%20on%20COVID-19%20confirmed%20cases%20and%20deaths%20in%20Queens%2C%20New%20York&amp;journal=Int.%20J.%20Environ.%20Res.%20Public%20Health&amp;volume=17&amp;publication_year=2020&amp;author=Adhikari%2CA&amp;author=Yin%2CJ">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">8.</span>
+                                       <p class="c-article-references__text" id="ref-CR8">Hoang, T. &amp; Tran, T. T. A. Ambient air pollution, meteorology, and COVID‐19 infection in Korea. <i>J. Med. Virol.</i> <b>93</b>, 878–885 (2021).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXhsVGku7vE" aria-label="CAS reference 8">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32691877" aria-label="PubMed reference 8" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1002%2Fjmv.26325" aria-label="Article reference 8">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 8" href="http://scholar.google.com/scholar_lookup?&amp;title=Ambient%20air%20pollution%2C%20meteorology%2C%20and%20COVID%E2%80%9019%20infection%20in%20Korea&amp;journal=J.%20Med.%20Virol.&amp;volume=93&amp;pages=878-885&amp;publication_year=2021&amp;author=Hoang%2CT&amp;author=Tran%2CTTA">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">9.</span>
+                                       <p class="c-article-references__text" id="ref-CR9">Meyer, A., Sadler, R., Faverjon, C., Cameron, A. R. &amp; Bannister-Tyrrell, M. Evidence that higher temperatures are associated with a marginally lower incidence of COVID-19 cases. <i>Front. Public Health</i> <b>8</b>, 367 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32754568" aria-label="PubMed reference 9" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7365860" aria-label="PubMed Central reference 9" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.3389%2Ffpubh.2020.00367" aria-label="Article reference 9">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 9" href="http://scholar.google.com/scholar_lookup?&amp;title=Evidence%20that%20higher%20temperatures%20are%20associated%20with%20a%20marginally%20lower%20incidence%20of%20COVID-19%20cases&amp;journal=Front.%20Public%20Health&amp;volume=8&amp;publication_year=2020&amp;author=Meyer%2CA&amp;author=Sadler%2CR&amp;author=Faverjon%2CC&amp;author=Cameron%2CAR&amp;author=Bannister-Tyrrell%2CM">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">10.</span>
+                                       <p class="c-article-references__text" id="ref-CR10">Pequeno, P. et al. Air transportation, population density and temperature predict the spread of COVID-19 in Brazil. <i>PeerJ</i> <b>8</b>, e9322 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32547889" aria-label="PubMed reference 10" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7275681" aria-label="PubMed Central reference 10" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.7717%2Fpeerj.9322" aria-label="Article reference 10">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3MXhs1ehtrjF" aria-label="CAS reference 10">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 10" href="http://scholar.google.com/scholar_lookup?&amp;title=Air%20transportation%2C%20population%20density%20and%20temperature%20predict%20the%20spread%20of%20COVID-19%20in%20Brazil&amp;journal=PeerJ&amp;volume=8&amp;publication_year=2020&amp;author=Pequeno%2CP">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">11.</span>
+                                       <p class="c-article-references__text" id="ref-CR11">Runkle, J. D. et al. Short-term effects of specific humidity and temperature on COVID-19 morbidity in select US cities. <i>Sci. Total Environ.</i> <b>740</b>, 140093 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://adsabs.harvard.edu/cgi-bin/nph-data_query?link_type=ABSTRACT&amp;bibcode=2020ScTEn.740n0093R" aria-label="ADS reference 11">ADS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXht1Wlt7vP" aria-label="CAS reference 11">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32540744" aria-label="PubMed reference 11" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7280823" aria-label="PubMed Central reference 11" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1016%2Fj.scitotenv.2020.140093" aria-label="Article reference 11">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 11" href="http://scholar.google.com/scholar_lookup?&amp;title=Short-term%20effects%20of%20specific%20humidity%20and%20temperature%20on%20COVID-19%20morbidity%20in%20select%20US%20cities&amp;journal=Sci.%20Total%20Environ.&amp;volume=740&amp;publication_year=2020&amp;author=Runkle%2CJD">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">12.</span>
+                                       <p class="c-article-references__text" id="ref-CR12">Rubin, D. et al. Association of social distancing, population density, and temperature with the instantaneous reproduction number of SARS-CoV-2 in counties across the United States. <i>JAMA Netw. Open</i> <b>3</b>, e2016099 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32701162" aria-label="PubMed reference 12" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7378754" aria-label="PubMed Central reference 12" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1001%2Fjamanetworkopen.2020.16099" aria-label="Article reference 12">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 12" href="http://scholar.google.com/scholar_lookup?&amp;title=Association%20of%20social%20distancing%2C%20population%20density%2C%20and%20temperature%20with%20the%20instantaneous%20reproduction%20number%20of%20SARS-CoV-2%20in%20counties%20across%20the%20United%20States&amp;journal=JAMA%20Netw.%20Open&amp;volume=3&amp;publication_year=2020&amp;author=Rubin%2CD">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">13.</span>
+                                       <p class="c-article-references__text" id="ref-CR13">Jüni, P. et al. Impact of climate and public health interventions on the COVID-19 pandemic: a prospective cohort study. <i>Can. Med. Assoc. J.</i> <b>192</b>, E566–E573 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1503%2Fcmaj.200920" aria-label="Article reference 13">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXhtFShs7%252FO" aria-label="CAS reference 13">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 13" href="http://scholar.google.com/scholar_lookup?&amp;title=Impact%20of%20climate%20and%20public%20health%20interventions%20on%20the%20COVID-19%20pandemic%3A%20a%20prospective%20cohort%20study&amp;journal=Can.%20Med.%20Assoc.%20J.&amp;volume=192&amp;pages=E566-E573&amp;publication_year=2020&amp;author=J%C3%BCni%2CP">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">14.</span>
+                                       <p class="c-article-references__text" id="ref-CR14">Carleton, T., Cornetet, J., Huybers, P., Meng, K. C. &amp; Proctor, J. Global evidence for ultraviolet radiation decreasing COVID-19 growth rates. <i>Proc. Natl Acad. Sci. USA</i> <b>118</b>, e2012370118 (2021).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3MXnsVOntw%253D%253D" aria-label="CAS reference 14">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=33323525" aria-label="PubMed reference 14" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1073%2Fpnas.2012370118" aria-label="Article reference 14">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 14" href="http://scholar.google.com/scholar_lookup?&amp;title=Global%20evidence%20for%20ultraviolet%20radiation%20decreasing%20COVID-19%20growth%20rates&amp;journal=Proc.%20Natl%20Acad.%20Sci.%20USA&amp;volume=118&amp;publication_year=2021&amp;author=Carleton%2CT&amp;author=Cornetet%2CJ&amp;author=Huybers%2CP&amp;author=Meng%2CKC&amp;author=Proctor%2CJ">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">15.</span>
+                                       <p class="c-article-references__text" id="ref-CR15">Smit, A. J. et al. Winter is coming: a Southern Hemisphere perspective of the environmental drivers of SARS-CoV-2 and the potential seasonality of COVID-19. <i>Int. J. Environ. Res. Public Health</i> <b>17</b>, 5634 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXitVGmsbbN" aria-label="CAS reference 15">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7459895" aria-label="PubMed Central reference 15" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.3390%2Fijerph17165634" aria-label="Article reference 15">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=7459895" aria-label="PubMed reference 15" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 15" href="http://scholar.google.com/scholar_lookup?&amp;title=Winter%20is%20coming%3A%20a%20Southern%20Hemisphere%20perspective%20of%20the%20environmental%20drivers%20of%20SARS-CoV-2%20and%20the%20potential%20seasonality%20of%20COVID-19&amp;journal=Int.%20J.%20Environ.%20Res.%20Public%20Health&amp;volume=17&amp;publication_year=2020&amp;author=Smit%2CAJ">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">16.</span>
+                                       <p class="c-article-references__text" id="ref-CR16">Mecenas, P., Bastos, R. T., da, R. M., Vallinoto, A. C. R. &amp; Normando, D. Effects of temperature and humidity on the spread of COVID-19: A systematic review. <i>PLoS ONE</i> <b>15</b>, e0238339 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXhvFahs7jK" aria-label="CAS reference 16">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32946453" aria-label="PubMed reference 16" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7500589" aria-label="PubMed Central reference 16" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1371%2Fjournal.pone.0238339" aria-label="Article reference 16">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 16" href="http://scholar.google.com/scholar_lookup?&amp;title=Effects%20of%20temperature%20and%20humidity%20on%20the%20spread%20of%20COVID-19%3A%20A%20systematic%20review&amp;journal=PLoS%20ONE&amp;volume=15&amp;publication_year=2020&amp;author=Mecenas%2CP&amp;author=Bastos%2CRT&amp;author=da%2CRM&amp;author=Vallinoto%2CACR&amp;author=Normando%2CD">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">17.</span>
+                                       <p class="c-article-references__text" id="ref-CR17">Briz-Redón, Á. &amp; Serrano-Aroca, Á. The effect of climate on the spread of the COVID-19 pandemic: a review of findings, and statistical and modelling techniques. <i>Prog. Phys. Geogr. Earth Environ.</i> <b>44</b>, 591–604 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1177%2F0309133320946302" aria-label="Article reference 17">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 17" href="http://scholar.google.com/scholar_lookup?&amp;title=The%20effect%20of%20climate%20on%20the%20spread%20of%20the%20COVID-19%20pandemic%3A%20a%20review%20of%20findings%2C%20and%20statistical%20and%20modelling%20techniques&amp;journal=Prog.%20Phys.%20Geogr.%20Earth%20Environ.&amp;volume=44&amp;pages=591-604&amp;publication_year=2020&amp;author=Briz-Red%C3%B3n%2C%C3%81&amp;author=Serrano-Aroca%2C%C3%81">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">18.</span>
+                                       <p class="c-article-references__text" id="ref-CR18">Abbott, S., Hellewell, J., Munday, J., Thompson, R. &amp; Funk, S. EpiNow: estimate realtime case counts and time-varying epidemiological parameters. <i>Zenodo</i> <a href="https://doi.org/10.5281/zenodo.3957489">https://doi.org/10.5281/zenodo.3957489</a> (2020).</p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">19.</span>
+                                       <p class="c-article-references__text" id="ref-CR19">Hersbach, H. et al. <i>ERA5 Hourly Data on Single Levels from 1979 to Present</i> (Copernicus Climate Change Service (C3S) Climate Data Store (CDS), 2018).</p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">20.</span>
+                                       <p class="c-article-references__text" id="ref-CR20">Sera, F., Armstrong, B., Blangiardo, M. &amp; Gasparrini, A. An extended mixed‐effects framework for meta‐analysis. <i>Stat. Med.</i> <b>38</b>, 5429–5444 (2019).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ams.org/mathscinet-getitem?mr=4032454" aria-label="MathSciNet reference 20">MathSciNet</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=31647135" aria-label="PubMed reference 20" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1002%2Fsim.8362" aria-label="Article reference 20">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 20" href="http://scholar.google.com/scholar_lookup?&amp;title=An%20extended%20mixed%E2%80%90effects%20framework%20for%20meta%E2%80%90analysis&amp;journal=Stat.%20Med.&amp;volume=38&amp;pages=5429-5444&amp;publication_year=2019&amp;author=Sera%2CF&amp;author=Armstrong%2CB&amp;author=Blangiardo%2CM&amp;author=Gasparrini%2CA">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">21.</span>
+                                       <p class="c-article-references__text" id="ref-CR21">Ratnesar-Shumate, S. et al. Simulated sunlight rapidly inactivates SARS-CoV-2 on surfaces. <i>J. Infect. Dis.</i> <b>222</b>, 214–222 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXhtl2ltbjK" aria-label="CAS reference 21">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32432672" aria-label="PubMed reference 21" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7313905" aria-label="PubMed Central reference 21" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1093%2Finfdis%2Fjiaa274" aria-label="Article reference 21">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 21" href="http://scholar.google.com/scholar_lookup?&amp;title=Simulated%20sunlight%20rapidly%20inactivates%20SARS-CoV-2%20on%20surfaces&amp;journal=J.%20Infect.%20Dis.&amp;volume=222&amp;pages=214-222&amp;publication_year=2020&amp;author=Ratnesar-Shumate%2CS">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">22.</span>
+                                       <p class="c-article-references__text" id="ref-CR22">Schuit, M. et al. Airborne SARS-CoV-2 is rapidly inactivated by simulated sunlight. <i>J. Infect. Dis.</i> <b>222</b>, 564–571 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXhsV2ksb%252FK" aria-label="CAS reference 22">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32525979" aria-label="PubMed reference 22" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7313838" aria-label="PubMed Central reference 22" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1093%2Finfdis%2Fjiaa334" aria-label="Article reference 22">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 22" href="http://scholar.google.com/scholar_lookup?&amp;title=Airborne%20SARS-CoV-2%20is%20rapidly%20inactivated%20by%20simulated%20sunlight&amp;journal=J.%20Infect.%20Dis.&amp;volume=222&amp;pages=564-571&amp;publication_year=2020&amp;author=Schuit%2CM">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">23.</span>
+                                       <p class="c-article-references__text" id="ref-CR23">Biryukov, J. et al. Increasing temperature and relative humidity accelerates inactivation of SARS-CoV-2 on surfaces. <i>mSphere</i> <b>5</b>, e00441–20 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXhs1Wjsr7P" aria-label="CAS reference 23">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32611701" aria-label="PubMed reference 23" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7333574" aria-label="PubMed Central reference 23" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1128%2FmSphere.00441-20" aria-label="Article reference 23">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 23" href="http://scholar.google.com/scholar_lookup?&amp;title=Increasing%20temperature%20and%20relative%20humidity%20accelerates%20inactivation%20of%20SARS-CoV-2%20on%20surfaces&amp;journal=mSphere&amp;volume=5&amp;pages=e00441-20&amp;publication_year=2020&amp;author=Biryukov%2CJ">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">24.</span>
+                                       <p class="c-article-references__text" id="ref-CR24">Chan, K.-H. et al. Factors affecting stability and infectivity of SARS-CoV-2. <i>J. Hosp. Infect.</i> <b>106</b>, 226–231 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32652214" aria-label="PubMed reference 24" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7343644" aria-label="PubMed Central reference 24" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1016%2Fj.jhin.2020.07.009" aria-label="Article reference 24">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 24" href="http://scholar.google.com/scholar_lookup?&amp;title=Factors%20affecting%20stability%20and%20infectivity%20of%20SARS-CoV-2&amp;journal=J.%20Hosp.%20Infect.&amp;volume=106&amp;pages=226-231&amp;publication_year=2020&amp;author=Chan%2CK-H">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">25.</span>
+                                       <p class="c-article-references__text" id="ref-CR25">Dabisch, P. et al. The influence of temperature, humidity, and simulated sunlight on the infectivity of SARS-CoV-2 in aerosols. <i>Aerosol Sci. Technol.</i> <b>55</b>, 142–153 (2021).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://adsabs.harvard.edu/cgi-bin/nph-data_query?link_type=ABSTRACT&amp;bibcode=2021AerST..55..142D" aria-label="ADS reference 25">ADS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXit1GgsrrM" aria-label="CAS reference 25">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1080%2F02786826.2020.1829536" aria-label="Article reference 25">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 25" href="http://scholar.google.com/scholar_lookup?&amp;title=The%20influence%20of%20temperature%2C%20humidity%2C%20and%20simulated%20sunlight%20on%20the%20infectivity%20of%20SARS-CoV-2%20in%20aerosols&amp;journal=Aerosol%20Sci.%20Technol.&amp;volume=55&amp;pages=142-153&amp;publication_year=2021&amp;author=Dabisch%2CP">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">26.</span>
+                                       <p class="c-article-references__text" id="ref-CR26">Zhao, L., Qi, Y., Luzzatto-Fegiz, P., Cui, Y. &amp; Zhu, Y. COVID-19: effects of environmental conditions on the propagation of respiratory droplets. <i>Nano Lett.</i> <b>20</b>, 7744–7750 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://adsabs.harvard.edu/cgi-bin/nph-data_query?link_type=ABSTRACT&amp;bibcode=2020NanoL..20.7744Z" aria-label="ADS reference 26">ADS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXhvVWhtrnE" aria-label="CAS reference 26">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32909761" aria-label="PubMed reference 26" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1021%2Facs.nanolett.0c03331" aria-label="Article reference 26">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 26" href="http://scholar.google.com/scholar_lookup?&amp;title=COVID-19%3A%20effects%20of%20environmental%20conditions%20on%20the%20propagation%20of%20respiratory%20droplets&amp;journal=Nano%20Lett.&amp;volume=20&amp;pages=7744-7750&amp;publication_year=2020&amp;author=Zhao%2CL&amp;author=Qi%2CY&amp;author=Luzzatto-Fegiz%2CP&amp;author=Cui%2CY&amp;author=Zhu%2CY">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">27.</span>
+                                       <p class="c-article-references__text" id="ref-CR27">Lowen, A. C., Mubareka, S., Steel, J. &amp; Palese, P. Influenza virus transmission is dependent on relative humidity and temperature. <i>PLoS Pathog.</i> <b>3</b>, e151 (2007).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2034399" aria-label="PubMed Central reference 27" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1371%2Fjournal.ppat.0030151" aria-label="Article reference 27">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BD2sXhsVOgu7jJ" aria-label="CAS reference 27">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=2034399" aria-label="PubMed reference 27" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 27" href="http://scholar.google.com/scholar_lookup?&amp;title=Influenza%20virus%20transmission%20is%20dependent%20on%20relative%20humidity%20and%20temperature&amp;journal=PLoS%20Pathog.&amp;volume=3&amp;publication_year=2007&amp;author=Lowen%2CAC&amp;author=Mubareka%2CS&amp;author=Steel%2CJ&amp;author=Palese%2CP">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">28.</span>
+                                       <p class="c-article-references__text" id="ref-CR28">Cannell, J. J. et al. Epidemic influenza and vitamin D. <i>Epidemiol. Infect.</i> <b>134</b>, 1129–1140 (2006).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BD28XhtFWns7rJ" aria-label="CAS reference 28">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=16959053" aria-label="PubMed reference 28" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2870528" aria-label="PubMed Central reference 28" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1017%2FS0950268806007175" aria-label="Article reference 28">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 28" href="http://scholar.google.com/scholar_lookup?&amp;title=Epidemic%20influenza%20and%20vitamin%20D&amp;journal=Epidemiol.%20Infect.&amp;volume=134&amp;pages=1129-1140&amp;publication_year=2006&amp;author=Cannell%2CJJ">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">29.</span>
+                                       <p class="c-article-references__text" id="ref-CR29">Grant, W. B. et al. Evidence that vitamin D supplementation could reduce risk of influenza and COVID-19 infections and deaths. <i>Nutrients</i> <b>12</b>, 988 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXhvVemsbnK" aria-label="CAS reference 29">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7231123" aria-label="PubMed Central reference 29" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.3390%2Fnu12040988" aria-label="Article reference 29">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=7231123" aria-label="PubMed reference 29" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 29" href="http://scholar.google.com/scholar_lookup?&amp;title=Evidence%20that%20vitamin%20D%20supplementation%20could%20reduce%20risk%20of%20influenza%20and%20COVID-19%20infections%20and%20deaths&amp;journal=Nutrients&amp;volume=12&amp;publication_year=2020&amp;author=Grant%2CWB">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">30.</span>
+                                       <p class="c-article-references__text" id="ref-CR30">Tamerius, J. et al. Global influenza seasonality: reconciling patterns across temperate and tropical regions. <i>Environ. Health Perspect.</i> <b>119</b>, 439–445 (2011).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=21097384" aria-label="PubMed reference 30" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1289%2Fehp.1002383" aria-label="Article reference 30">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 30" href="http://scholar.google.com/scholar_lookup?&amp;title=Global%20influenza%20seasonality%3A%20reconciling%20patterns%20across%20temperate%20and%20tropical%20regions&amp;journal=Environ.%20Health%20Perspect.&amp;volume=119&amp;pages=439-445&amp;publication_year=2011&amp;author=Tamerius%2CJ">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">31.</span>
+                                       <p class="c-article-references__text" id="ref-CR31">Sun, Z., Thilakavathy, K., Kumar, S. S., He, G. &amp; Liu, S. V. Potential factors influencing repeated SARS outbreaks in China. <i>Int. J. Environ. Res. Public. Health</i> <b>17</b>, 1633 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXhslyrs7rL" aria-label="CAS reference 31">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7084229" aria-label="PubMed Central reference 31" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.3390%2Fijerph17051633" aria-label="Article reference 31">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=7084229" aria-label="PubMed reference 31" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 31" href="http://scholar.google.com/scholar_lookup?&amp;title=Potential%20factors%20influencing%20repeated%20SARS%20outbreaks%20in%20China&amp;journal=Int.%20J.%20Environ.%20Res.%20Public.%20Health&amp;volume=17&amp;publication_year=2020&amp;author=Sun%2CZ&amp;author=Thilakavathy%2CK&amp;author=Kumar%2CSS&amp;author=He%2CG&amp;author=Liu%2CSV">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">32.</span>
+                                       <p class="c-article-references__text" id="ref-CR32">Kudo, E. et al. Low ambient humidity impairs barrier function and innate resistance against influenza infection. <i>Proc. Natl Acad. Sci. USA</i> <b>116</b>, 10905–10910 (2019).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BC1MXhtVChsrzF" aria-label="CAS reference 32">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=31085641" aria-label="PubMed reference 32" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC6561219" aria-label="PubMed Central reference 32" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1073%2Fpnas.1902840116" aria-label="Article reference 32">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 32" href="http://scholar.google.com/scholar_lookup?&amp;title=Low%20ambient%20humidity%20impairs%20barrier%20function%20and%20innate%20resistance%20against%20influenza%20infection&amp;journal=Proc.%20Natl%20Acad.%20Sci.%20USA&amp;volume=116&amp;pages=10905-10910&amp;publication_year=2019&amp;author=Kudo%2CE">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">33.</span>
+                                       <p class="c-article-references__text" id="ref-CR33">Moriyama, M. &amp; Ichinohe, T. High ambient temperature dampens adaptive immune responses to influenza A virus infection. <i>Proc. Natl Acad. Sci. USA</i> <b>116</b>, 3118–3125 (2019).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BC1MXjtlClsLk%253D" aria-label="CAS reference 33">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=30718396" aria-label="PubMed reference 33" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC6386664" aria-label="PubMed Central reference 33" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1073%2Fpnas.1815029116" aria-label="Article reference 33">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 33" href="http://scholar.google.com/scholar_lookup?&amp;title=High%20ambient%20temperature%20dampens%20adaptive%20immune%20responses%20to%20influenza%20A%20virus%20infection&amp;journal=Proc.%20Natl%20Acad.%20Sci.%20USA&amp;volume=116&amp;pages=3118-3125&amp;publication_year=2019&amp;author=Moriyama%2CM&amp;author=Ichinohe%2CT">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">34.</span>
+                                       <p class="c-article-references__text" id="ref-CR34">Fares, A. Factors influencing the seasonal patterns of infectious diseases. <i>Int. J. Prev. Med.</i> <b>4</b>, 128–132 (2013).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://adsabs.harvard.edu/cgi-bin/nph-data_query?link_type=ABSTRACT&amp;bibcode=2013ggc2.book.....F" aria-label="ADS reference 34">ADS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=23543865" aria-label="PubMed reference 34" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC3604842" aria-label="PubMed Central reference 34" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 34" href="http://scholar.google.com/scholar_lookup?&amp;title=Factors%20influencing%20the%20seasonal%20patterns%20of%20infectious%20diseases&amp;journal=Int.%20J.%20Prev.%20Med.&amp;volume=4&amp;pages=128-132&amp;publication_year=2013&amp;author=Fares%2CA">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">35.</span>
+                                       <p class="c-article-references__text" id="ref-CR35">Wu, Y. et al. Effects of temperature and humidity on the daily new cases and new deaths of COVID-19 in 166 countries. <i>Sci. Total Environ.</i> <b>729</b>, 139051 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://adsabs.harvard.edu/cgi-bin/nph-data_query?link_type=ABSTRACT&amp;bibcode=2020ScTEn.729m9051W" aria-label="ADS reference 35">ADS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXosVymt7o%253D" aria-label="CAS reference 35">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32361460" aria-label="PubMed reference 35" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7187824" aria-label="PubMed Central reference 35" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1016%2Fj.scitotenv.2020.139051" aria-label="Article reference 35">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 35" href="http://scholar.google.com/scholar_lookup?&amp;title=Effects%20of%20temperature%20and%20humidity%20on%20the%20daily%20new%20cases%20and%20new%20deaths%20of%20COVID-19%20in%20166%20countries&amp;journal=Sci.%20Total%20Environ.&amp;volume=729&amp;publication_year=2020&amp;author=Wu%2CY">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">36.</span>
+                                       <p class="c-article-references__text" id="ref-CR36">Villeneuve, P. J. &amp; Goldberg, M. S. Methodological considerations for epidemiological studies of air pollution and the SARS and COVID-19 coronavirus outbreaks. <i>Environ. Health Perspect.</i> <b>128</b>, 095001 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7480171" aria-label="PubMed Central reference 36" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1289%2FEHP7411" aria-label="Article reference 36">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=7480171" aria-label="PubMed reference 36" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 36" href="http://scholar.google.com/scholar_lookup?&amp;title=Methodological%20considerations%20for%20epidemiological%20studies%20of%20air%20pollution%20and%20the%20SARS%20and%20COVID-19%20coronavirus%20outbreaks&amp;journal=Environ.%20Health%20Perspect.&amp;volume=128&amp;publication_year=2020&amp;author=Villeneuve%2CPJ&amp;author=Goldberg%2CMS">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">37.</span>
+                                       <p class="c-article-references__text" id="ref-CR37">Heederik, D. J. J., Smit, L. A. M. &amp; Vermeulen, R. C. H. Go slow to go fast: a plea for sustained scientific rigour in air pollution research during the COVID-19 pandemic. <i>Eur. Respir. J.</i> <b>56</b>, 2001361 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXitVCjtbzL" aria-label="CAS reference 37">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32586882" aria-label="PubMed reference 37" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7315812" aria-label="PubMed Central reference 37" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1183%2F13993003.01361-2020" aria-label="Article reference 37">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 37" href="http://scholar.google.com/scholar_lookup?&amp;title=Go%20slow%20to%20go%20fast%3A%20a%20plea%20for%20sustained%20scientific%20rigour%20in%20air%20pollution%20research%20during%20the%20COVID-19%20pandemic&amp;journal=Eur.%20Respir.%20J.&amp;volume=56&amp;publication_year=2020&amp;author=Heederik%2CDJJ&amp;author=Smit%2CLAM&amp;author=Vermeulen%2CRCH">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">38.</span>
+                                       <p class="c-article-references__text" id="ref-CR38">Imai, C., Armstrong, B., Chalabi, Z., Mangtani, P. &amp; Hashizume, M. Time series regression model for infectious disease and weather. <i>Environ. Res.</i> <b>142</b>, 319–327 (2015).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BC2MXhtF2ktLjJ" aria-label="CAS reference 38">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=26188633" aria-label="PubMed reference 38" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1016%2Fj.envres.2015.06.040" aria-label="Article reference 38">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 38" href="http://scholar.google.com/scholar_lookup?&amp;title=Time%20series%20regression%20model%20for%20infectious%20disease%20and%20weather&amp;journal=Environ.%20Res.&amp;volume=142&amp;pages=319-327&amp;publication_year=2015&amp;author=Imai%2CC&amp;author=Armstrong%2CB&amp;author=Chalabi%2CZ&amp;author=Mangtani%2CP&amp;author=Hashizume%2CM">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">39.</span>
+                                       <p class="c-article-references__text" id="ref-CR39">Liu, Y., Morgenstern, C., Kelly, J., Lowe, R. &amp; Jit, M. The impact of non-pharmaceutical interventions on SARS-CoV-2 transmission across 130 countries and territories. <i>BMC Med.</i> <b>19</b>, 40 (2021).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=33541353" aria-label="PubMed reference 39" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7861967" aria-label="PubMed Central reference 39" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1186%2Fs12916-020-01872-8" aria-label="Article reference 39">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3MXjslajt7s%253D" aria-label="CAS reference 39">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 39" href="http://scholar.google.com/scholar_lookup?&amp;title=The%20impact%20of%20non-pharmaceutical%20interventions%20on%20SARS-CoV-2%20transmission%20across%20130%20countries%20and%20territories&amp;journal=BMC%20Med.&amp;volume=19&amp;publication_year=2021&amp;author=Liu%2CY&amp;author=Morgenstern%2CC&amp;author=Kelly%2CJ&amp;author=Lowe%2CR&amp;author=Jit%2CM">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">40.</span>
+                                       <p class="c-article-references__text" id="ref-CR40">Li, R. et al. Substantial undocumented infection facilitates the rapid dissemination of novel coronavirus (SARS-CoV-2). <i>Science</i> <b>368</b>, 489–493 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://adsabs.harvard.edu/cgi-bin/nph-data_query?link_type=ABSTRACT&amp;bibcode=2020Sci...368..489L" aria-label="ADS reference 40">ADS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXosVSjur0%253D" aria-label="CAS reference 40">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=7164387" aria-label="PubMed reference 40" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7164387" aria-label="PubMed Central reference 40" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1126%2Fscience.abb3221" aria-label="Article reference 40">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 40" href="http://scholar.google.com/scholar_lookup?&amp;title=Substantial%20undocumented%20infection%20facilitates%20the%20rapid%20dissemination%20of%20novel%20coronavirus%20%28SARS-CoV-2%29&amp;journal=Science&amp;volume=368&amp;pages=489-493&amp;publication_year=2020&amp;author=Li%2CR">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">41.</span>
+                                       <p class="c-article-references__text" id="ref-CR41">Rocklöv, J. &amp; Sjödin, H. High population densities catalyse the spread of COVID-19. <i>J. Travel Med.</i> <b>27</b>, taaa038 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32227186" aria-label="PubMed reference 41" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1093%2Fjtm%2Ftaaa038" aria-label="Article reference 41">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 41" href="http://scholar.google.com/scholar_lookup?&amp;title=High%20population%20densities%20catalyse%20the%20spread%20of%20COVID-19&amp;journal=J.%20Travel%20Med.&amp;volume=27&amp;publication_year=2020&amp;author=Rockl%C3%B6v%2CJ&amp;author=Sj%C3%B6din%2CH">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">42.</span>
+                                       <p class="c-article-references__text" id="ref-CR42">Davies, N. G. et al. Age-dependent effects in the transmission and control of COVID-19 epidemics. <i>Nat. Med.</i> <b>26</b>, 1205–1211 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXhtFOqtL3E" aria-label="CAS reference 42">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32546824" aria-label="PubMed reference 42" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1038%2Fs41591-020-0962-9" aria-label="Article reference 42">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 42" href="http://scholar.google.com/scholar_lookup?&amp;title=Age-dependent%20effects%20in%20the%20transmission%20and%20control%20of%20COVID-19%20epidemics&amp;journal=Nat.%20Med.&amp;volume=26&amp;pages=1205-1211&amp;publication_year=2020&amp;author=Davies%2CNG">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">43.</span>
+                                       <p class="c-article-references__text" id="ref-CR43">Patel, J. A. et al. Poverty, inequality and COVID-19: the forgotten vulnerable. <i>Public Health</i> <b>183</b>, 110–111 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ASTN%3A280%3ADC%252BB38rmtlegtA%253D%253D" aria-label="CAS reference 43">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32502699" aria-label="PubMed reference 43" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1016%2Fj.puhe.2020.05.006" aria-label="Article reference 43">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 43" href="http://scholar.google.com/scholar_lookup?&amp;title=Poverty%2C%20inequality%20and%20COVID-19%3A%20the%20forgotten%20vulnerable&amp;journal=Public%20Health&amp;volume=183&amp;pages=110-111&amp;publication_year=2020&amp;author=Patel%2CJA">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">44.</span>
+                                       <p class="c-article-references__text" id="ref-CR44">Borro, M. et al. Evidence-based considerations exploring relations between SARS-CoV-2 pandemic and air pollution: involvement of PM2.5-mediated up-regulation of the viral receptor ACE-2. <i>Int. J. Environ. Res. Public. Health</i> <b>17</b>, 5573 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXitVGhs77L" aria-label="CAS reference 44">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7432777" aria-label="PubMed Central reference 44" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.3390%2Fijerph17155573" aria-label="Article reference 44">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=7432777" aria-label="PubMed reference 44" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 44" href="http://scholar.google.com/scholar_lookup?&amp;title=Evidence-based%20considerations%20exploring%20relations%20between%20SARS-CoV-2%20pandemic%20and%20air%20pollution%3A%20involvement%20of%20PM2.5-mediated%20up-regulation%20of%20the%20viral%20receptor%20ACE-2&amp;journal=Int.%20J.%20Environ.%20Res.%20Public.%20Health&amp;volume=17&amp;publication_year=2020&amp;author=Borro%2CM">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">45.</span>
+                                       <p class="c-article-references__text" id="ref-CR45">Pozzer, A. et al. Regional and global contributions of air pollution to risk of death from COVID-19. <i>Cardiovasc. Res.</i> <b>116</b>, 2247–2253 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3MXntFaqt7s%253D" aria-label="CAS reference 45">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=33236040" aria-label="PubMed reference 45" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7797754" aria-label="PubMed Central reference 45" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1093%2Fcvr%2Fcvaa288" aria-label="Article reference 45">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 45" href="http://scholar.google.com/scholar_lookup?&amp;title=Regional%20and%20global%20contributions%20of%20air%20pollution%20to%20risk%20of%20death%20from%20COVID-19&amp;journal=Cardiovasc.%20Res.&amp;volume=116&amp;pages=2247-2253&amp;publication_year=2020&amp;author=Pozzer%2CA">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">46.</span>
+                                       <p class="c-article-references__text" id="ref-CR46">Jiang, Y., Wu, X.-J. &amp; Guan, Y.-J. Effect of ambient air pollutants and meteorological variables on COVID-19 incidence. <i>Infect. Control Hosp. Epidemiol.</i> <b>41</b>, 1011–1015 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32389157" aria-label="PubMed reference 46" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1017%2Fice.2020.222" aria-label="Article reference 46">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3cXpvFKqsrw%253D" aria-label="CAS reference 46">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 46" href="http://scholar.google.com/scholar_lookup?&amp;title=Effect%20of%20ambient%20air%20pollutants%20and%20meteorological%20variables%20on%20COVID-19%20incidence&amp;journal=Infect.%20Control%20Hosp.%20Epidemiol.&amp;volume=41&amp;pages=1011-1015&amp;publication_year=2020&amp;author=Jiang%2CY&amp;author=Wu%2CX-J&amp;author=Guan%2CY-J">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">47.</span>
+                                       <p class="c-article-references__text" id="ref-CR47">Ryti, N. R. I., Korpelainen, A., Seppänen, O. &amp; Jaakkola, J. J. K. Paradoxical home temperatures during cold weather: a proof-of-concept study. <i>Int. J. Biometeorol.</i> <b>64</b>, 2065–2076 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://adsabs.harvard.edu/cgi-bin/nph-data_query?link_type=ABSTRACT&amp;bibcode=2020IJBm...64.2065R" aria-label="ADS reference 47">ADS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32852609" aria-label="PubMed reference 47" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7658083" aria-label="PubMed Central reference 47" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1007%2Fs00484-020-01998-7" aria-label="Article reference 47">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 47" href="http://scholar.google.com/scholar_lookup?&amp;title=Paradoxical%20home%20temperatures%20during%20cold%20weather%3A%20a%20proof-of-concept%20study&amp;journal=Int.%20J.%20Biometeorol.&amp;volume=64&amp;pages=2065-2076&amp;publication_year=2020&amp;author=Ryti%2CNRI&amp;author=Korpelainen%2CA&amp;author=Sepp%C3%A4nen%2CO&amp;author=Jaakkola%2CJJK">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">48.</span>
+                                       <p class="c-article-references__text" id="ref-CR48">Marr, L. C., Tang, J. W., Van Mullekom, J. &amp; Lakdawala, S. S. Mechanistic insights into the effect of humidity on airborne influenza virus survival, transmission and incidence. <i>J. R. Soc. Interface</i> <b>16</b>, 20180298 (2019).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BC1MXhtFGgsL%252FM" aria-label="CAS reference 48">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=30958176" aria-label="PubMed reference 48" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC6364647" aria-label="PubMed Central reference 48" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1098%2Frsif.2018.0298" aria-label="Article reference 48">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 48" href="http://scholar.google.com/scholar_lookup?&amp;title=Mechanistic%20insights%20into%20the%20effect%20of%20humidity%20on%20airborne%20influenza%20virus%20survival%2C%20transmission%20and%20incidence&amp;journal=J.%20R.%20Soc.%20Interface&amp;volume=16&amp;publication_year=2019&amp;author=Marr%2CLC&amp;author=Tang%2CJW&amp;author=Mullekom%2CJ&amp;author=Lakdawala%2CSS">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">49.</span>
+                                       <p class="c-article-references__text" id="ref-CR49">Nguyen, J. L., Schwartz, J. &amp; Dockery, D. W. The relationship between indoor and outdoor temperature, apparent temperature, relative humidity, and absolute humidity. <i>Indoor Air</i> <b>24</b>, 103–112 (2014).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ASTN%3A280%3ADC%252BC3snmvFyktA%253D%253D" aria-label="CAS reference 49">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=23710826" aria-label="PubMed reference 49" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1111%2Fina.12052" aria-label="Article reference 49">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 49" href="http://scholar.google.com/scholar_lookup?&amp;title=The%20relationship%20between%20indoor%20and%20outdoor%20temperature%2C%20apparent%20temperature%2C%20relative%20humidity%2C%20and%20absolute%20humidity&amp;journal=Indoor%20Air&amp;volume=24&amp;pages=103-112&amp;publication_year=2014&amp;author=Nguyen%2CJL&amp;author=Schwartz%2CJ&amp;author=Dockery%2CDW">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">50.</span>
+                                       <p class="c-article-references__text" id="ref-CR50">Gasparrini, A. et al. Mortality risk attributable to high and low ambient temperature: a multicountry observational study. <i>Lancet</i> <b>386</b>, 369–375 (2015).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=4521077" aria-label="PubMed reference 50" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4521077" aria-label="PubMed Central reference 50" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1016%2FS0140-6736%2814%2962114-0" aria-label="Article reference 50">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 50" href="http://scholar.google.com/scholar_lookup?&amp;title=Mortality%20risk%20attributable%20to%20high%20and%20low%20ambient%20temperature%3A%20a%20multicountry%20observational%20study&amp;journal=Lancet&amp;volume=386&amp;pages=369-375&amp;publication_year=2015&amp;author=Gasparrini%2CA">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">51.</span>
+                                       <p class="c-article-references__text" id="ref-CR51">Abbott, S. et al. Estimating the time-varying reproduction number of SARS-CoV-2 using national and subnational case counts. <i>Wellcome Open Res.</i> <b>5</b>, 112 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.12688%2Fwellcomeopenres.16006.1" aria-label="Article reference 51">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 51" href="http://scholar.google.com/scholar_lookup?&amp;title=Estimating%20the%20time-varying%20reproduction%20number%20of%20SARS-CoV-2%20using%20national%20and%20subnational%20case%20counts&amp;journal=Wellcome%20Open%20Res.&amp;volume=5&amp;publication_year=2020&amp;author=Abbott%2CS">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">52.</span>
+                                       <p class="c-article-references__text" id="ref-CR52">Sherratt, K. et al. Exploring surveillance data biases when estimating the reproduction number: with insights into subpopulation transmission of Covid-19 in England. <i>Philos. Trans. R. Soc. B</i> <b>376</b>, 20200283 (2021).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="/articles/cas-redirect/1%3ACAS%3A528%3ADC%252BB3MXhs1OnsLvF" aria-label="CAS reference 52">CAS</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1098%2Frstb.2020.0283" aria-label="Article reference 52">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 52" href="http://scholar.google.com/scholar_lookup?&amp;title=Exploring%20surveillance%20data%20biases%20when%20estimating%20the%20reproduction%20number%3A%20with%20insights%20into%20subpopulation%20transmission%20of%20Covid-19%20in%20England&amp;journal=Philos.%20Trans.%20R.%20Soc.%20B&amp;volume=376&amp;publication_year=2021&amp;author=Sherratt%2CK">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">53.</span>
+                                       <p class="c-article-references__text" id="ref-CR53">Stan Development Team. <i>RStan: The R interface to Stan</i> (Stan Development Team, 2020).</p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">54.</span>
+                                       <p class="c-article-references__text" id="ref-CR54">Abbott, S. et al. Estimating the time-varying reproduction number of SARS-CoV-2 using national and subnational case counts. <i>Wellcome Open Res.</i> <b>5</b>, 112 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.12688%2Fwellcomeopenres.16006.1" aria-label="Article reference 54">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 54" href="http://scholar.google.com/scholar_lookup?&amp;title=Estimating%20the%20time-varying%20reproduction%20number%20of%20SARS-CoV-2%20using%20national%20and%20subnational%20case%20counts&amp;journal=Wellcome%20Open%20Res.&amp;volume=5&amp;publication_year=2020&amp;author=Abbott%2CS">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">55.</span>
+                                       <p class="c-article-references__text" id="ref-CR55">Ganyani, T. et al. Estimating the generation interval for coronavirus disease (COVID-19) based on symptom onset data, March 2020. <i>Eurosurveillance</i> <b>25</b>, 2000257 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC7201952" aria-label="PubMed Central reference 55" rel="nofollow">PubMed Central</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.2807%2F1560-7917.ES.2020.25.17.2000257" aria-label="Article reference 55">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=7201952" aria-label="PubMed reference 55" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 55" href="http://scholar.google.com/scholar_lookup?&amp;title=Estimating%20the%20generation%20interval%20for%20coronavirus%20disease%20%28COVID-19%29%20based%20on%20symptom%20onset%20data%2C%20March%202020&amp;journal=Eurosurveillance&amp;volume=25&amp;publication_year=2020&amp;author=Ganyani%2CT">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">56.</span>
+                                       <p class="c-article-references__text" id="ref-CR56">Ferretti, L. et al. The timing of COVID-19 transmission. Preprint at <i>medRxiv</i> <a href="https://doi.org/10.1101/2020.09.04.20188516">https://doi.org/10.1101/2020.09.04.20188516</a> (2020).</p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">57.</span>
+                                       <p class="c-article-references__text" id="ref-CR57">Lauer, S. A. et al. The incubation period of Coronavirus Disease 2019 (COVID-19) from publicly reported confirmed cases: estimation and application. <i>Ann. Intern. Med.</i> <b>172</b>, 577–582 (2020).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=32150748" aria-label="PubMed reference 57" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.7326%2FM20-0504" aria-label="Article reference 57">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 57" href="http://scholar.google.com/scholar_lookup?&amp;title=The%20incubation%20period%20of%20Coronavirus%20Disease%202019%20%28COVID-19%29%20from%20publicly%20reported%20confirmed%20cases%3A%20estimation%20and%20application&amp;journal=Ann.%20Intern.%20Med.&amp;volume=172&amp;pages=577-582&amp;publication_year=2020&amp;author=Lauer%2CSA">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">58.</span>
+                                       <p class="c-article-references__text" id="ref-CR58">Jun, C. Calculate water vapor measures from temperature and dew point. <a href="https://github.com/caijun/humidity">https://github.com/caijun/humidity</a> (2019).</p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">59.</span>
+                                       <p class="c-article-references__text" id="ref-CR59">Shi, P. et al. The impact of temperature and absolute humidity on the coronavirus disease 2019 (COVID-19) outbreak - evidence from China. Preprint at <i>medRxiv</i> <a href="https://doi.org/10.1101/2020.03.22.20038919">https://doi.org/10.1101/2020.03.22.20038919</a> (2020).</p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">60.</span>
+                                       <p class="c-article-references__text" id="ref-CR60">OECD. OECD regions at a glance 2016. <a href="https://doi.org/10.1787/reg_glance-2016-en">https://doi.org/10.1787/reg_glance-2016-en</a> (2016).</p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">61.</span>
+                                       <p class="c-article-references__text" id="ref-CR61">Simplemaps. World cities database. <a href="https://simplemaps.com/data/world-cities">https://simplemaps.com/data/world-cities</a> (2016).</p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">62.</span>
+                                       <p class="c-article-references__text" id="ref-CR62">Christophe, Y. et al. <i>Validation Report of the CAMS Near-Real-Time Global Atmospheric Composition Service: Period March–May 2019</i>. Copernicus Atmosphere Monitoring Service (CAMS) Report (2019).</p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">63.</span>
+                                       <p class="c-article-references__text" id="ref-CR63">Morcrette, J.-J. et al. Aerosol analysis and forecast in the European Centre for medium-range weather forecasts integrated forecast system: forward modeling. <i>J. Geophys. Res. Atmos.</i> <b>114</b>, <a href="https://doi.org/10.1029/2008JD011235">https://doi.org/10.1029/2008JD011235</a> (2009).</p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">64.</span>
+                                       <p class="c-article-references__text" id="ref-CR64">Benedetti, A. et al. Aerosol analysis and forecast in the European centre for medium-range weather forecasts integrated forecast system: 2. Data assimilation. <i>J. Geophys. Res. Atmos.</i> <b>114</b>, <a href="https://doi.org/10.1029/2008JD011115">https://doi.org/10.1029/2008JD011115</a> (2009).</p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">65.</span>
+                                       <p class="c-article-references__text" id="ref-CR65">Hale, T. et al. <i>Variation in Government Responses to COVID-19</i>. Blavatnik School of Government Working Paper. <a href="http://www.bsg.ox.ac.uk/covidtracker">www.bsg.ox.ac.uk/covidtracker</a> (2021).</p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">66.</span>
+                                       <p class="c-article-references__text" id="ref-CR66">Higgins, J. P. T. &amp; Thompson, S. G. Quantifying heterogeneity in a meta-analysis. <i>Stat. Med.</i> <b>21</b>, 1539–1558 (2002).</p>
+                                       <p class="c-article-references__links u-hide-print"><a data-track="click" data-track-action="outbound reference" data-track-label="link" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=Retrieve&amp;db=PubMed&amp;dopt=Abstract&amp;list_uids=12111919" aria-label="PubMed reference 66" rel="nofollow">PubMed</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" href="https://doi.org/10.1002%2Fsim.1186" aria-label="Article reference 66">Article</a>\xa0\n    <a data-track="click" data-track-action="outbound reference" data-track-label="link" aria-label="Google Scholar reference 66" href="http://scholar.google.com/scholar_lookup?&amp;title=Quantifying%20heterogeneity%20in%20a%20meta-analysis&amp;journal=Stat.%20Med.&amp;volume=21&amp;pages=1539-1558&amp;publication_year=2002&amp;author=Higgins%2CJPT&amp;author=Thompson%2CSG">\n                    Google Scholar</a>\xa0\n                </p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">67.</span>
+                                       <p class="c-article-references__text" id="ref-CR67">Kramer, M. R2 statistics for mixed models. <i>Conf. Appl. Stat. Agric</i>. <a href="https://doi.org/10.4148/2475-7772.1142">https://doi.org/10.4148/2475-7772.1142</a> (2005).</p>
+                                    </li>
+                                    <li class="c-article-references__item js-c-reading-companion-references-item">
+                                       <span class="c-article-references__counter">68.</span>
+                                       <p class="c-article-references__text" id="ref-CR68">Sera, F., Abbott, S. &amp; Royé. Data and code to replicate the analysis of the paper. ‘A cross-sectional analysis of meteorological factors and SARS-CoV-2 transmission in 409 cities across 26 countries’. <a href="https://doi.org/10.5281/zenodo.5215842">https://doi.org/10.5281/zenodo.5215842</a> (2021).</p>
+                                    </li>
+                                 </ol>
+                                 <p class="c-article-references__download u-hide-print">
+                                    <a data-track="click" data-track-action="download citation references" data-track-label="link" href="https://citation-needed.springer.com/v2/references/10.1038/s41467-021-25914-8?format=refman&amp;flavour=references">
+                                       Download references
+                                       <svg width="16" height="16" focusable="false" role="img" aria-hidden="true" class="u-icon">
+                                          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#global-icon-download"></use>
+                                       </svg>
+                                    </a>
+                                 </p>
+                              </div>
+                           </div>
+                        </div>
+                     </section>
+                  </div>
+                  <section data-title="Acknowledgements">
+                     <div class="c-article-section" id="Ack1-section">
+                        <h2 class="c-article-section__title js-section-title js-c-reading-companion-sections-item" id="Ack1">Acknowledgements</h2>
+                        <div class="c-article-section__content" id="Ack1-content">
+                           <p>This work was generated using Copernicus Climate Change Service (C3S) and Copernicus Atmosphere Monitoring Service (CAMS) information [2020]. The authors would like to thank the European Centre for Medium-Range Weather Forecasts (ECMWF) that implements the C3S and CAMS on behalf of the European Union. D.R. was supported by a postdoctoral research fellowship of the Xunta de Galicia (Spain). A.G. was funded by the Medical Research Council-UK (Grant ID: MR/R013349/1), the Natural Environment Research Council UK (Grant ID: NE/R009384/1) and the European Union’s Horizon 2020 Project Exhaustion (Grant ID: 820655). R.L. was supported by a Royal Society Dorothy Hodgkin Fellowship. S.A. and S.M. were funded by the Wellcome Trust (grant\xa0210758/Z/18/Z210758/Z/18/Z).\xa0The following funding sources are acknowledged as providing funding for the MCC Collaborative Research Network authors: J.K. and A.U. were supported by the Czech Science Foundation, project 18-22125S. S.T. was supported by the Shanghai Municipal Science and Technology Commission (Grant 18411951600). N.S. is supported by the NIEHS-funded HERCULES Center (P30ES019776). H.K. was supported by the National Research Foundation of Korea (BK21 Center for Integrative Response to Health Disasters, Graduate School of Public Health, Seoul National University). A.S., F.D.R. and S.R. were funded by the European Union’s Horizon 2020 Project Exhaustion (Grant ID: 820655). Each member of the CMMID COVID-19 Working Group contributed to processing, cleaning and interpretation of data, interpreted findings, contributed to the manuscript and approved the work for publication. The following funding sources are acknowledged as providing funding for the CMMID COVID-19 working group authors. This research was partly funded by the Bill &amp; Melinda Gates Foundation (INV-001754: M.Q; INV-003174: K.P., M.J., Y.L., J.L.; NTD Modelling Consortium OPP1184344: C.A.B.P., G.M.; OPP1180644: S.R.P.; OPP1183986: E.S.N.). BMGF (OPP1157270: K.E.A.). DFID/Wellcome Trust (Epidemic Preparedness Coronavirus research programme 221303/Z/20/Z: C.A.B.P.). EDCTP2 (RIA2020EF-2983-CSIGN: H.P.G.). ERC Starting Grant (#757699: M.Q.). This project has received funding from the European Union’s Horizon 2020 research and innovation programme—project EpiPose (101003688: K.P., M.J., P.K., R.C.B., W.J.E., Y.L.). This research was partly funded by the Global Challenges Research Fund (GCRF) project ‘RECAP’ managed through RCUK and ESRC (ES/P010873/1: A.G., C.I.J., T.J.). HDR UK (MR/S003975/1: R.M.E.). MRC (MR/N013638/1: N.R.W.; MR/V027956/1: W.W.). Nakajima Foundation (A.E.). This research was partly funded by the National Institute for Health Research (NIHR) using UK aid from the UK Government to support global health research. The views expressed in this publication are those of the author(s) and not necessarily those of the NIHR or the UK Department of Health and Social Care (16/136/46: B.J.Q.; 16/137/109: B.J.Q., F.Y.S., M.J., Y.L.; Health Protection Research Unit for Immunisation NIHR200929: N.G.D.; Health Protection Research Unit for Modelling Methodology HPRU-2012-10096: T.J.; NIHR200908: R.M.E.; NIHR200929: F.G.S., M.J.; PR-OD-1017-20002: A.R., W.J.E.). Royal Society (Dorothy Hodgkin Fellowship: R.L.; RP\\EA\\180004: P.K.). UK DHSC/UK Aid/NIHR (PR-OD-1017-20001: H.P.G.). UK MRC (MC_PC_19065—Covid 19: Understanding the dynamics and drivers of the COVID-19 epidemic using real-time outbreak analytics: A.G., N.G.D., R.M.E., S.C., T.J., W.J.E., Y.L.; MR/P014658/1: G.M.K.). Authors of this research receive funding from the UK Public Health Rapid Support Team funded by the United Kingdom Department of Health and Social Care (T.J.). Wellcome Trust (206250/Z/17/Z: A.J.K., T.W.R.; 206471/Z/17/Z: O.B.; 208812/Z/17/Z: S.C.; 210758/Z/18/Z: J.D.M., J.H., N.I.B.; UNS110424: F.K.). No funding (A.M.F., A.S., C.J.V.-A., D.C.T., J.W., K.E.A., Y.-W.D.C.). LSHTM, DHSC/UKRI COVID-19 Rapid Response Initiative (MR/V028456/1: Y.L.). Innovation Fund of the Joint Federal Committee (01VSF18015: F.K.). Foreign, Commonwealth and Development Office/Wellcome Trust (221303/Z/20/Z: M.K.).</p>
+                        </div>
+                     </div>
+                  </section>
+                  <section aria-labelledby="author-information" data-title="Author information">
+                     <div class="c-article-section" id="author-information-section">
+                        <h2 class="c-article-section__title js-section-title js-c-reading-companion-sections-item" id="author-information">Author information</h2>
+                        <div class="c-article-section__content" id="author-information-content">
+                           <h3 class="c-article__sub-heading" id="affiliations">Affiliations</h3>
+                           <ol class="c-article-author-affiliation__list">
+                              <li id="Aff1">
+                                 <p class="c-article-author-affiliation__address">Department of Public Health, Environments and Society, London School of Hygiene &amp; Tropical Medicine, London, UK</p>
+                                 <p class="c-article-author-affiliation__authors-list">Francesco Sera,\xa0Ben Armstrong,\xa0Rochelle Schneider\xa0&amp;\xa0Antonio Gasparrini</p>
+                              </li>
+                              <li id="Aff2">
+                                 <p class="c-article-author-affiliation__address">Department of Statistics, Computer Science and Applications “G. Parenti”, University of Florence, Florence, Italy</p>
+                                 <p class="c-article-author-affiliation__authors-list">Francesco Sera</p>
+                              </li>
+                              <li id="Aff3">
+                                 <p class="c-article-author-affiliation__address">Centre for Mathematical Modelling of Infectious Diseases, London School of Hygiene &amp; Tropical Medicine, London, UK</p>
+                                 <p class="c-article-author-affiliation__authors-list">Sam Abbott,\xa0Sophie Meakin,\xa0Kathleen O’Reilly,\xa0Timothy W. Russell,\xa0Mihaly Koltai,\xa0Adam J. Kucharski,\xa0Rosanna C. Barnard,\xa0Matthew Quaife,\xa0Christopher I. Jarvis,\xa0Jiayao Lei,\xa0James D. Munday,\xa0Yung-Wai Desmond Chan,\xa0Billy J. Quilty,\xa0Rosalind M. Eggo,\xa0Stefan Flasche,\xa0Anna M. Foss,\xa0Samuel Clifford,\xa0Damien C. Tully,\xa0W. John Edmunds,\xa0Petra Klepac,\xa0Oliver Brady,\xa0Fabienne Krauer,\xa0Simon R. Procter,\xa0Thibaut Jombart,\xa0Alicia Rosello,\xa0Alicia Showering,\xa0Sebastian Funk,\xa0Joel Hellewell,\xa0Fiona Yueqian Sun,\xa0Akira Endo,\xa0Jack Williams,\xa0Amy Gimma,\xa0Naomi R. Waterlow,\xa0Kiesha Prem,\xa0Nikos I. Bosse,\xa0Hamish P. Gibbs,\xa0Katherine E. Atkins,\xa0Carl A. B. Pearson,\xa0Yalda Jafari,\xa0C. Julian Villabona-Arenas,\xa0Mark Jit,\xa0Emily S. Nightingale,\xa0Nicholas G. Davies,\xa0Kevin van Zandvoort,\xa0Yang Liu,\xa0Frank G. Sandmann,\xa0William Waites,\xa0Kaja Abbas,\xa0Graham Medley,\xa0Gwenan M. Knight\xa0&amp;\xa0Rachel Lowe</p>
+                              </li>
+                              <li id="Aff4">
+                                 <p class="c-article-author-affiliation__address">Department of Infectious Disease Epidemiology, London School of Hygiene &amp; Tropical Medicine, London, UK</p>
+                                 <p class="c-article-author-affiliation__authors-list">Sam Abbott,\xa0Sophie Meakin,\xa0Kathleen O’Reilly\xa0&amp;\xa0Rachel Lowe</p>
+                              </li>
+                              <li id="Aff5">
+                                 <p class="c-article-author-affiliation__address">Charité Universitätsmedizin, Berlin, Germany</p>
+                                 <p class="c-article-author-affiliation__authors-list">Rosa von Borries</p>
+                              </li>
+                              <li id="Aff6">
+                                 <p class="c-article-author-affiliation__address">Centre on Climate Change and Planetary Health, London School of Hygiene &amp; Tropical Medicine, London, UK</p>
+                                 <p class="c-article-author-affiliation__authors-list">Rochelle Schneider,\xa0Antonio Gasparrini\xa0&amp;\xa0Rachel Lowe</p>
+                              </li>
+                              <li id="Aff7">
+                                 <p class="c-article-author-affiliation__address">Forecast Department, European Centre for Medium-Range Weather Forecast (ECMWF), Reading, UK</p>
+                                 <p class="c-article-author-affiliation__authors-list">Rochelle Schneider</p>
+                              </li>
+                              <li id="Aff8">
+                                 <p class="c-article-author-affiliation__address">Φ-Lab, European Space Agency, Frascati, Italy</p>
+                                 <p class="c-article-author-affiliation__authors-list">Rochelle Schneider</p>
+                              </li>
+                              <li id="Aff9">
+                                 <p class="c-article-author-affiliation__address">Department of Geography, CIBER of Epidemiology and Public Health (CIBERESP), University of Santiago de Compostela, Santiago de Compostela, Spain</p>
+                                 <p class="c-article-author-affiliation__authors-list">Dominic Royé</p>
+                              </li>
+                              <li id="Aff10">
+                                 <p class="c-article-author-affiliation__address">Department of Paediatric Infectious Disease, Institute of Tropical Medicine, Nagasaki University, Nagasaki, Japan</p>
+                                 <p class="c-article-author-affiliation__authors-list">Masahiro Hashizume</p>
+                              </li>
+                              <li id="Aff11">
+                                 <p class="c-article-author-affiliation__address">School of Tropical Medicine and Global Health, Nagasaki University, Nagasaki, Japan</p>
+                                 <p class="c-article-author-affiliation__authors-list">Masahiro Hashizume,\xa0Aurelio Tobias,\xa0Chris Fook Sheng Ng\xa0&amp;\xa0Xerxes Seposo</p>
+                              </li>
+                              <li id="Aff12">
+                                 <p class="c-article-author-affiliation__address">Department of Global Health Policy, Graduate School of Medicine, The University of Tokyo, Tokyo, Japan</p>
+                                 <p class="c-article-author-affiliation__authors-list">Masahiro Hashizume</p>
+                              </li>
+                              <li id="Aff13">
+                                 <p class="c-article-author-affiliation__address">Santé Publique France, Department of Environmental and Occupational Health, French National Public Health Agency, Saint Maurice, France</p>
+                                 <p class="c-article-author-affiliation__authors-list">Mathilde Pascal</p>
+                              </li>
+                              <li id="Aff14">
+                                 <p class="c-article-author-affiliation__address">Institute of Environmental Assessment and Water Research (IDAEA), Spanish Council for Scientific Research (CSIS), Barcelona, Spain</p>
+                                 <p class="c-article-author-affiliation__authors-list">Aurelio Tobias</p>
+                              </li>
+                              <li id="Aff15">
+                                 <p class="c-article-author-affiliation__address">Institute of Social and Preventive Medicine, University of Bern, Bern, Switzerland</p>
+                                 <p class="c-article-author-affiliation__authors-list">Ana Maria Vicedo-Cabrera</p>
+                              </li>
+                              <li id="Aff16">
+                                 <p class="c-article-author-affiliation__address">Oeschger Center for Climate Change Research, University of Bern, Bern, Switzerland</p>
+                                 <p class="c-article-author-affiliation__authors-list">Ana Maria Vicedo-Cabrera</p>
+                              </li>
+                              <li id="Aff17">
+                                 <p class="c-article-author-affiliation__address">Centre for Statistical Modelling, London School of Hygiene &amp; Tropical Medicine, London, UK</p>
+                                 <p class="c-article-author-affiliation__authors-list">Antonio Gasparrini</p>
+                              </li>
+                              <li id="Aff18">
+                                 <p class="c-article-author-affiliation__address">Barcelona Supercomputing Center, Barcelona, Spain</p>
+                                 <p class="c-article-author-affiliation__authors-list">Rachel Lowe</p>
+                              </li>
+                              <li id="Aff19">
+                                 <p class="c-article-author-affiliation__address">School of Public Health and Social Work, Queensland University of Technology, Brisbane, QLD, Australia</p>
+                                 <p class="c-article-author-affiliation__authors-list">Wenbiao Hu\xa0&amp;\xa0Shilu Tong</p>
+                              </li>
+                              <li id="Aff20">
+                                 <p class="c-article-author-affiliation__address">Shanghai Children’s Medical Centre, School of Medicine, Shanghai Jiao-Tong University, Shanghai, China</p>
+                                 <p class="c-article-author-affiliation__authors-list">Shilu Tong</p>
+                              </li>
+                              <li id="Aff21">
+                                 <p class="c-article-author-affiliation__address">School of Public Health, Institute of Environment and Human Health, Anhui Medical University, Hefei, China</p>
+                                 <p class="c-article-author-affiliation__authors-list">Shilu Tong</p>
+                              </li>
+                              <li id="Aff22">
+                                 <p class="c-article-author-affiliation__address">Center for Global Health, School of Public Health, Nanjing Medical University, Nanjing, China</p>
+                                 <p class="c-article-author-affiliation__authors-list">Shilu Tong</p>
+                              </li>
+                              <li id="Aff23">
+                                 <p class="c-article-author-affiliation__address">School of Epidemiology and Public Health, Faculty of Medicine, University of Ottawa, Ottawa, ON, Canada</p>
+                                 <p class="c-article-author-affiliation__authors-list">Eric Lavigne</p>
+                              </li>
+                              <li id="Aff24">
+                                 <p class="c-article-author-affiliation__address">Air Health Science Division, Health Canada, Ottawa, ON, Canada</p>
+                                 <p class="c-article-author-affiliation__authors-list">Eric Lavigne</p>
+                              </li>
+                              <li id="Aff25">
+                                 <p class="c-article-author-affiliation__address">Department of Public Health, Universidad de los Andes, Santiago, Chile</p>
+                                 <p class="c-article-author-affiliation__authors-list">Patricia Matus Correa</p>
+                              </li>
+                              <li id="Aff26">
+                                 <p class="c-article-author-affiliation__address">Key Lab of Public Health Safety of the Ministry of Education and NHC Key Lab of Health Technology Assessment, School of Public Health, Fudan University, Shanghai, China</p>
+                                 <p class="c-article-author-affiliation__authors-list">Xia Meng\xa0&amp;\xa0Haidong Kan</p>
+                              </li>
+                              <li id="Aff27">
+                                 <p class="c-article-author-affiliation__address">Department of Infectious Diseases Eepidemiology, National Institute of Public Health, Prague, Czech Republic</p>
+                                 <p class="c-article-author-affiliation__authors-list">Jan Kynčl</p>
+                              </li>
+                              <li id="Aff28">
+                                 <p class="c-article-author-affiliation__address">Department of Epidemiology and Biostatistics, Third Faculty of Medicine, Charles University, Prague, Czech Republic</p>
+                                 <p class="c-article-author-affiliation__authors-list">Jan Kynčl</p>
+                              </li>
+                              <li id="Aff29">
+                                 <p class="c-article-author-affiliation__address">Institute of Atmospheric Physics of the Czech Academy of Sciences, Prague, Czech Republic</p>
+                                 <p class="c-article-author-affiliation__authors-list">Aleš Urban</p>
+                              </li>
+                              <li id="Aff30">
+                                 <p class="c-article-author-affiliation__address">Faculty of Environmental Sciences, Czech University of Life Sciences, Prague, Czech Republic</p>
+                                 <p class="c-article-author-affiliation__authors-list">Aleš Urban</p>
+                              </li>
+                              <li id="Aff31">
+                                 <p class="c-article-author-affiliation__address"> Institute of Family Medicine and Public Health, University of Tartu, Tartu, Estonia</p>
+                                 <p class="c-article-author-affiliation__authors-list">Hans Orru</p>
+                              </li>
+                              <li id="Aff32">
+                                 <p class="c-article-author-affiliation__address">Center for Environmental and Respiratory Health Research (CERH), University of Oulu, Oulu, Finland</p>
+                                 <p class="c-article-author-affiliation__authors-list">Niilo R. I. Ryti\xa0&amp;\xa0Jouni J. K. Jaakkola</p>
+                              </li>
+                              <li id="Aff33">
+                                 <p class="c-article-author-affiliation__address">Medical Research Center Oulu (MRC Oulu), Oulu University Hospital and University of Oulu, Oulu, Finland</p>
+                                 <p class="c-article-author-affiliation__authors-list">Niilo R. I. Ryti\xa0&amp;\xa0Jouni J. K. Jaakkola</p>
+                              </li>
+                              <li id="Aff34">
+                                 <p class="c-article-author-affiliation__address">Mathematical Modelling of Infectious Diseases Unit, Institut Pasteur, Paris, France</p>
+                                 <p class="c-article-author-affiliation__authors-list">Simon Cauchemez</p>
+                              </li>
+                              <li id="Aff35">
+                                 <p class="c-article-author-affiliation__address">Institute of Epidemiology, Helmholtz Zentrum München—German Research Center for Environmental Health (GmbH), Neuherberg, Germany</p>
+                                 <p class="c-article-author-affiliation__authors-list">Marco Dallavalle\xa0&amp;\xa0Alexandra Schneider</p>
+                              </li>
+                              <li id="Aff36">
+                                 <p class="c-article-author-affiliation__address">Institute of Environment, Health and Societies, Brunel University London, London, UK</p>
+                                 <p class="c-article-author-affiliation__authors-list">Ariana Zeka</p>
+                              </li>
+                              <li id="Aff37">
+                                 <p class="c-article-author-affiliation__address">Center for Climate Change Adaptation, National Institute for Environmental Studies, Tsukuba, Japan</p>
+                                 <p class="c-article-author-affiliation__authors-list">Yasushi Honda</p>
+                              </li>
+                              <li id="Aff38">
+                                 <p class="c-article-author-affiliation__address">Faculty of Health and Sport Sciences, University of Tsukuba, Tsukuba, Japan</p>
+                                 <p class="c-article-author-affiliation__authors-list">Yasushi Honda</p>
+                              </li>
+                              <li id="Aff39">
+                                 <p class="c-article-author-affiliation__address">Department of Environmental Health, Harvard T.H. Chan School of Public Health, Harvard University, Boston, MA, USA</p>
+                                 <p class="c-article-author-affiliation__authors-list">Barrak Alahmad,\xa0Antonella Zanobetti\xa0&amp;\xa0Joel Schwartz</p>
+                              </li>
+                              <li id="Aff40">
+                                 <p class="c-article-author-affiliation__address">Norwegian Institute of Public Health, Oslo, Norway</p>
+                                 <p class="c-article-author-affiliation__authors-list">Shilpa Rao\xa0&amp;\xa0Francesco Di Ruscio</p>
+                              </li>
+                              <li id="Aff41">
+                                 <p class="c-article-author-affiliation__address">Health Innovation Laboratory, Institute of Tropical Medicine “Alexander von Humboldt”, Universidad Peruana Cayetano Heredia, Lima, Peru</p>
+                                 <p class="c-article-author-affiliation__authors-list">Gabriel Carrasco-Escobar</p>
+                              </li>
+                              <li id="Aff42">
+                                 <p class="c-article-author-affiliation__address">Scripps Institution of Oceanography, University of California San Diego, La Jolla, CA, USA</p>
+                                 <p class="c-article-author-affiliation__authors-list">Gabriel Carrasco-Escobar</p>
+                              </li>
+                              <li id="Aff43">
+                                 <p class="c-article-author-affiliation__address">Faculty of Geography, Babes-Bolyai University, Cluj-Napoca, Romania</p>
+                                 <p class="c-article-author-affiliation__authors-list">Iulian Horia Holobâcă</p>
+                              </li>
+                              <li id="Aff44">
+                                 <p class="c-article-author-affiliation__address">Department of Public Health Science, Graduate School of Public Health, Institute of Health and Environment, Seoul National University, Seoul, Republic of Korea</p>
+                                 <p class="c-article-author-affiliation__authors-list">Ho Kim\xa0&amp;\xa0Whanhee Lee</p>
+                              </li>
+                              <li id="Aff45">
+                                 <p class="c-article-author-affiliation__address">Department of Statistics and Computational Research, Universitat de València, València, Spain</p>
+                                 <p class="c-article-author-affiliation__authors-list">Carmen Íñiguez</p>
+                              </li>
+                              <li id="Aff46">
+                                 <p class="c-article-author-affiliation__address">Swiss Tropical and Public Health Institute, Basel, Switzerland</p>
+                                 <p class="c-article-author-affiliation__authors-list">Martina S. Ragettli</p>
+                              </li>
+                              <li id="Aff47">
+                                 <p class="c-article-author-affiliation__address">University of Basel, Basel, Switzerland</p>
+                                 <p class="c-article-author-affiliation__authors-list">Martina S. Ragettli</p>
+                              </li>
+                              <li id="Aff48">
+                                 <p class="c-article-author-affiliation__address">Departament of Preventive and Social Medicine, School of Medicine, Universidad de la República, Montevideo, Uruguay</p>
+                                 <p class="c-article-author-affiliation__authors-list">Alicia Aleman</p>
+                              </li>
+                              <li id="Aff49">
+                                 <p class="c-article-author-affiliation__address">Departmente of Cuantitative Methods, School of Medicine, Universidad de la República, Montevideo, Uruguay</p>
+                                 <p class="c-article-author-affiliation__authors-list">Valentina Colistro</p>
+                              </li>
+                              <li id="Aff50">
+                                 <p class="c-article-author-affiliation__address">School of the Environment, Yale University, New Haven, CT, USA</p>
+                                 <p class="c-article-author-affiliation__authors-list">Michelle L. Bell</p>
+                              </li>
+                              <li id="Aff51">
+                                 <p class="c-article-author-affiliation__address">Department of Environmental Health, Faculty of Public Health, University of Medicine and Pharmacy at Ho Chi Minh City, Ho Chi Minh City, Vietnam</p>
+                                 <p class="c-article-author-affiliation__authors-list">Tran Ngoc Dang</p>
+                              </li>
+                              <li id="Aff52">
+                                 <p class="c-article-author-affiliation__address">Gangarosa Department of Environmental Health. Rollins School of Public Health, Emory University, Atlanta, GA, USA</p>
+                                 <p class="c-article-author-affiliation__authors-list">Noah Scovronick</p>
+                              </li>
+                              <li id="Aff53">
+                                 <p class="c-article-author-affiliation__address">Department of Pathology, Faculty of Medicine, University of São Paulo, São Paulo, Brazil</p>
+                                 <p class="c-article-author-affiliation__authors-list">Micheline de Sousa Zanotti Stagliorio Coélho</p>
+                              </li>
+                              <li id="Aff54">
+                                 <p class="c-article-author-affiliation__address">Department of Environmental Health, National Institute of Public Health, Cuernavaca, Morelos, Mexico</p>
+                                 <p class="c-article-author-affiliation__authors-list">Magali Hurtado Diaz</p>
+                              </li>
+                              <li id="Aff55">
+                                 <p class="c-article-author-affiliation__address">College of Computer Science and Technology, Zhejiang University, Hangzhou, China</p>
+                                 <p class="c-article-author-affiliation__authors-list">Yuzhou Zhang</p>
+                              </li>
+                              <li id="Aff56">
+                                 <p class="c-article-author-affiliation__address">Department of Research, Baolue Technology (Zhejiang) Co., Ltd, Hangzhou, China</p>
+                                 <p class="c-article-author-affiliation__authors-list">Yuzhou Zhang</p>
+                              </li>
+                           </ol>
+                           <div class="u-js-hide u-hide-print" data-test="author-info">
+                              <span class="c-article__sub-heading">Authors</span>
+                              <ol class="c-article-authors-search u-list-reset">
+                                 <li id="auth-Francesco-Sera">
+                                    <span class="c-article-authors-search__title u-h3 js-search-name">Francesco Sera</span>
+                                    <div class="c-article-authors-search__list">
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--left"><a href="/search?author=&#34;Francesco+Sera&#34;" class="c-article-button" data-track="click" data-track-action="author link - publication" data-track-label="link">View author publications</a></div>
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--right">
+                                          <p class="search-in-title-js c-article-authors-search__text">You can also search for this author in\n                        <span class="c-article-identifiers"><a class="c-article-identifiers__item" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=search&amp;term=Francesco+Sera" data-track="click" data-track-action="author link - pubmed" data-track-label="link">PubMed</a><span class="u-hide">\xa0</span><a class="c-article-identifiers__item" href="http://scholar.google.co.uk/scholar?as_q=&amp;num=10&amp;btnG=Search+Scholar&amp;as_epq=&amp;as_oq=&amp;as_eq=&amp;as_occt=any&amp;as_sauthors=%22Francesco+Sera%22&amp;as_publication=&amp;as_ylo=&amp;as_yhi=&amp;as_allsubj=all&amp;hl=en" data-track="click" data-track-action="author link - scholar" data-track-label="link">Google Scholar</a></span></p>
+                                       </div>
+                                    </div>
+                                 </li>
+                                 <li id="auth-Ben-Armstrong">
+                                    <span class="c-article-authors-search__title u-h3 js-search-name">Ben Armstrong</span>
+                                    <div class="c-article-authors-search__list">
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--left"><a href="/search?author=&#34;Ben+Armstrong&#34;" class="c-article-button" data-track="click" data-track-action="author link - publication" data-track-label="link">View author publications</a></div>
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--right">
+                                          <p class="search-in-title-js c-article-authors-search__text">You can also search for this author in\n                        <span class="c-article-identifiers"><a class="c-article-identifiers__item" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=search&amp;term=Ben+Armstrong" data-track="click" data-track-action="author link - pubmed" data-track-label="link">PubMed</a><span class="u-hide">\xa0</span><a class="c-article-identifiers__item" href="http://scholar.google.co.uk/scholar?as_q=&amp;num=10&amp;btnG=Search+Scholar&amp;as_epq=&amp;as_oq=&amp;as_eq=&amp;as_occt=any&amp;as_sauthors=%22Ben+Armstrong%22&amp;as_publication=&amp;as_ylo=&amp;as_yhi=&amp;as_allsubj=all&amp;hl=en" data-track="click" data-track-action="author link - scholar" data-track-label="link">Google Scholar</a></span></p>
+                                       </div>
+                                    </div>
+                                 </li>
+                                 <li id="auth-Sam-Abbott">
+                                    <span class="c-article-authors-search__title u-h3 js-search-name">Sam Abbott</span>
+                                    <div class="c-article-authors-search__list">
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--left"><a href="/search?author=&#34;Sam+Abbott&#34;" class="c-article-button" data-track="click" data-track-action="author link - publication" data-track-label="link">View author publications</a></div>
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--right">
+                                          <p class="search-in-title-js c-article-authors-search__text">You can also search for this author in\n                        <span class="c-article-identifiers"><a class="c-article-identifiers__item" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=search&amp;term=Sam+Abbott" data-track="click" data-track-action="author link - pubmed" data-track-label="link">PubMed</a><span class="u-hide">\xa0</span><a class="c-article-identifiers__item" href="http://scholar.google.co.uk/scholar?as_q=&amp;num=10&amp;btnG=Search+Scholar&amp;as_epq=&amp;as_oq=&amp;as_eq=&amp;as_occt=any&amp;as_sauthors=%22Sam+Abbott%22&amp;as_publication=&amp;as_ylo=&amp;as_yhi=&amp;as_allsubj=all&amp;hl=en" data-track="click" data-track-action="author link - scholar" data-track-label="link">Google Scholar</a></span></p>
+                                       </div>
+                                    </div>
+                                 </li>
+                                 <li id="auth-Sophie-Meakin">
+                                    <span class="c-article-authors-search__title u-h3 js-search-name">Sophie Meakin</span>
+                                    <div class="c-article-authors-search__list">
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--left"><a href="/search?author=&#34;Sophie+Meakin&#34;" class="c-article-button" data-track="click" data-track-action="author link - publication" data-track-label="link">View author publications</a></div>
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--right">
+                                          <p class="search-in-title-js c-article-authors-search__text">You can also search for this author in\n                        <span class="c-article-identifiers"><a class="c-article-identifiers__item" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=search&amp;term=Sophie+Meakin" data-track="click" data-track-action="author link - pubmed" data-track-label="link">PubMed</a><span class="u-hide">\xa0</span><a class="c-article-identifiers__item" href="http://scholar.google.co.uk/scholar?as_q=&amp;num=10&amp;btnG=Search+Scholar&amp;as_epq=&amp;as_oq=&amp;as_eq=&amp;as_occt=any&amp;as_sauthors=%22Sophie+Meakin%22&amp;as_publication=&amp;as_ylo=&amp;as_yhi=&amp;as_allsubj=all&amp;hl=en" data-track="click" data-track-action="author link - scholar" data-track-label="link">Google Scholar</a></span></p>
+                                       </div>
+                                    </div>
+                                 </li>
+                                 <li id="auth-Kathleen-O_Reilly">
+                                    <span class="c-article-authors-search__title u-h3 js-search-name">Kathleen O’Reilly</span>
+                                    <div class="c-article-authors-search__list">
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--left"><a href="/search?author=&#34;Kathleen+O%E2%80%99Reilly&#34;" class="c-article-button" data-track="click" data-track-action="author link - publication" data-track-label="link">View author publications</a></div>
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--right">
+                                          <p class="search-in-title-js c-article-authors-search__text">You can also search for this author in\n                        <span class="c-article-identifiers"><a class="c-article-identifiers__item" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=search&amp;term=Kathleen+O%E2%80%99Reilly" data-track="click" data-track-action="author link - pubmed" data-track-label="link">PubMed</a><span class="u-hide">\xa0</span><a class="c-article-identifiers__item" href="http://scholar.google.co.uk/scholar?as_q=&amp;num=10&amp;btnG=Search+Scholar&amp;as_epq=&amp;as_oq=&amp;as_eq=&amp;as_occt=any&amp;as_sauthors=%22Kathleen+O%E2%80%99Reilly%22&amp;as_publication=&amp;as_ylo=&amp;as_yhi=&amp;as_allsubj=all&amp;hl=en" data-track="click" data-track-action="author link - scholar" data-track-label="link">Google Scholar</a></span></p>
+                                       </div>
+                                    </div>
+                                 </li>
+                                 <li id="auth-Rosa-Borries">
+                                    <span class="c-article-authors-search__title u-h3 js-search-name">Rosa von Borries</span>
+                                    <div class="c-article-authors-search__list">
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--left"><a href="/search?author=&#34;Rosa+von+Borries&#34;" class="c-article-button" data-track="click" data-track-action="author link - publication" data-track-label="link">View author publications</a></div>
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--right">
+                                          <p class="search-in-title-js c-article-authors-search__text">You can also search for this author in\n                        <span class="c-article-identifiers"><a class="c-article-identifiers__item" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=search&amp;term=Rosa+von+Borries" data-track="click" data-track-action="author link - pubmed" data-track-label="link">PubMed</a><span class="u-hide">\xa0</span><a class="c-article-identifiers__item" href="http://scholar.google.co.uk/scholar?as_q=&amp;num=10&amp;btnG=Search+Scholar&amp;as_epq=&amp;as_oq=&amp;as_eq=&amp;as_occt=any&amp;as_sauthors=%22Rosa+von+Borries%22&amp;as_publication=&amp;as_ylo=&amp;as_yhi=&amp;as_allsubj=all&amp;hl=en" data-track="click" data-track-action="author link - scholar" data-track-label="link">Google Scholar</a></span></p>
+                                       </div>
+                                    </div>
+                                 </li>
+                                 <li id="auth-Rochelle-Schneider">
+                                    <span class="c-article-authors-search__title u-h3 js-search-name">Rochelle Schneider</span>
+                                    <div class="c-article-authors-search__list">
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--left"><a href="/search?author=&#34;Rochelle+Schneider&#34;" class="c-article-button" data-track="click" data-track-action="author link - publication" data-track-label="link">View author publications</a></div>
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--right">
+                                          <p class="search-in-title-js c-article-authors-search__text">You can also search for this author in\n                        <span class="c-article-identifiers"><a class="c-article-identifiers__item" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=search&amp;term=Rochelle+Schneider" data-track="click" data-track-action="author link - pubmed" data-track-label="link">PubMed</a><span class="u-hide">\xa0</span><a class="c-article-identifiers__item" href="http://scholar.google.co.uk/scholar?as_q=&amp;num=10&amp;btnG=Search+Scholar&amp;as_epq=&amp;as_oq=&amp;as_eq=&amp;as_occt=any&amp;as_sauthors=%22Rochelle+Schneider%22&amp;as_publication=&amp;as_ylo=&amp;as_yhi=&amp;as_allsubj=all&amp;hl=en" data-track="click" data-track-action="author link - scholar" data-track-label="link">Google Scholar</a></span></p>
+                                       </div>
+                                    </div>
+                                 </li>
+                                 <li id="auth-Dominic-Roy_">
+                                    <span class="c-article-authors-search__title u-h3 js-search-name">Dominic Royé</span>
+                                    <div class="c-article-authors-search__list">
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--left"><a href="/search?author=&#34;Dominic+Roy%C3%A9&#34;" class="c-article-button" data-track="click" data-track-action="author link - publication" data-track-label="link">View author publications</a></div>
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--right">
+                                          <p class="search-in-title-js c-article-authors-search__text">You can also search for this author in\n                        <span class="c-article-identifiers"><a class="c-article-identifiers__item" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=search&amp;term=Dominic+Roy%C3%A9" data-track="click" data-track-action="author link - pubmed" data-track-label="link">PubMed</a><span class="u-hide">\xa0</span><a class="c-article-identifiers__item" href="http://scholar.google.co.uk/scholar?as_q=&amp;num=10&amp;btnG=Search+Scholar&amp;as_epq=&amp;as_oq=&amp;as_eq=&amp;as_occt=any&amp;as_sauthors=%22Dominic+Roy%C3%A9%22&amp;as_publication=&amp;as_ylo=&amp;as_yhi=&amp;as_allsubj=all&amp;hl=en" data-track="click" data-track-action="author link - scholar" data-track-label="link">Google Scholar</a></span></p>
+                                       </div>
+                                    </div>
+                                 </li>
+                                 <li id="auth-Masahiro-Hashizume">
+                                    <span class="c-article-authors-search__title u-h3 js-search-name">Masahiro Hashizume</span>
+                                    <div class="c-article-authors-search__list">
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--left"><a href="/search?author=&#34;Masahiro+Hashizume&#34;" class="c-article-button" data-track="click" data-track-action="author link - publication" data-track-label="link">View author publications</a></div>
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--right">
+                                          <p class="search-in-title-js c-article-authors-search__text">You can also search for this author in\n                        <span class="c-article-identifiers"><a class="c-article-identifiers__item" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=search&amp;term=Masahiro+Hashizume" data-track="click" data-track-action="author link - pubmed" data-track-label="link">PubMed</a><span class="u-hide">\xa0</span><a class="c-article-identifiers__item" href="http://scholar.google.co.uk/scholar?as_q=&amp;num=10&amp;btnG=Search+Scholar&amp;as_epq=&amp;as_oq=&amp;as_eq=&amp;as_occt=any&amp;as_sauthors=%22Masahiro+Hashizume%22&amp;as_publication=&amp;as_ylo=&amp;as_yhi=&amp;as_allsubj=all&amp;hl=en" data-track="click" data-track-action="author link - scholar" data-track-label="link">Google Scholar</a></span></p>
+                                       </div>
+                                    </div>
+                                 </li>
+                                 <li id="auth-Mathilde-Pascal">
+                                    <span class="c-article-authors-search__title u-h3 js-search-name">Mathilde Pascal</span>
+                                    <div class="c-article-authors-search__list">
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--left"><a href="/search?author=&#34;Mathilde+Pascal&#34;" class="c-article-button" data-track="click" data-track-action="author link - publication" data-track-label="link">View author publications</a></div>
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--right">
+                                          <p class="search-in-title-js c-article-authors-search__text">You can also search for this author in\n                        <span class="c-article-identifiers"><a class="c-article-identifiers__item" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=search&amp;term=Mathilde+Pascal" data-track="click" data-track-action="author link - pubmed" data-track-label="link">PubMed</a><span class="u-hide">\xa0</span><a class="c-article-identifiers__item" href="http://scholar.google.co.uk/scholar?as_q=&amp;num=10&amp;btnG=Search+Scholar&amp;as_epq=&amp;as_oq=&amp;as_eq=&amp;as_occt=any&amp;as_sauthors=%22Mathilde+Pascal%22&amp;as_publication=&amp;as_ylo=&amp;as_yhi=&amp;as_allsubj=all&amp;hl=en" data-track="click" data-track-action="author link - scholar" data-track-label="link">Google Scholar</a></span></p>
+                                       </div>
+                                    </div>
+                                 </li>
+                                 <li id="auth-Aurelio-Tobias">
+                                    <span class="c-article-authors-search__title u-h3 js-search-name">Aurelio Tobias</span>
+                                    <div class="c-article-authors-search__list">
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--left"><a href="/search?author=&#34;Aurelio+Tobias&#34;" class="c-article-button" data-track="click" data-track-action="author link - publication" data-track-label="link">View author publications</a></div>
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--right">
+                                          <p class="search-in-title-js c-article-authors-search__text">You can also search for this author in\n                        <span class="c-article-identifiers"><a class="c-article-identifiers__item" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=search&amp;term=Aurelio+Tobias" data-track="click" data-track-action="author link - pubmed" data-track-label="link">PubMed</a><span class="u-hide">\xa0</span><a class="c-article-identifiers__item" href="http://scholar.google.co.uk/scholar?as_q=&amp;num=10&amp;btnG=Search+Scholar&amp;as_epq=&amp;as_oq=&amp;as_eq=&amp;as_occt=any&amp;as_sauthors=%22Aurelio+Tobias%22&amp;as_publication=&amp;as_ylo=&amp;as_yhi=&amp;as_allsubj=all&amp;hl=en" data-track="click" data-track-action="author link - scholar" data-track-label="link">Google Scholar</a></span></p>
+                                       </div>
+                                    </div>
+                                 </li>
+                                 <li id="auth-Ana_Maria-Vicedo_Cabrera">
+                                    <span class="c-article-authors-search__title u-h3 js-search-name">Ana Maria Vicedo-Cabrera</span>
+                                    <div class="c-article-authors-search__list">
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--left"><a href="/search?author=&#34;Ana Maria+Vicedo-Cabrera&#34;" class="c-article-button" data-track="click" data-track-action="author link - publication" data-track-label="link">View author publications</a></div>
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--right">
+                                          <p class="search-in-title-js c-article-authors-search__text">You can also search for this author in\n                        <span class="c-article-identifiers"><a class="c-article-identifiers__item" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=search&amp;term=Ana Maria+Vicedo-Cabrera" data-track="click" data-track-action="author link - pubmed" data-track-label="link">PubMed</a><span class="u-hide">\xa0</span><a class="c-article-identifiers__item" href="http://scholar.google.co.uk/scholar?as_q=&amp;num=10&amp;btnG=Search+Scholar&amp;as_epq=&amp;as_oq=&amp;as_eq=&amp;as_occt=any&amp;as_sauthors=%22Ana Maria+Vicedo-Cabrera%22&amp;as_publication=&amp;as_ylo=&amp;as_yhi=&amp;as_allsubj=all&amp;hl=en" data-track="click" data-track-action="author link - scholar" data-track-label="link">Google Scholar</a></span></p>
+                                       </div>
+                                    </div>
+                                 </li>
+                                 <li id="auth-Antonio-Gasparrini">
+                                    <span class="c-article-authors-search__title u-h3 js-search-name">Antonio Gasparrini</span>
+                                    <div class="c-article-authors-search__list">
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--left"><a href="/search?author=&#34;Antonio+Gasparrini&#34;" class="c-article-button" data-track="click" data-track-action="author link - publication" data-track-label="link">View author publications</a></div>
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--right">
+                                          <p class="search-in-title-js c-article-authors-search__text">You can also search for this author in\n                        <span class="c-article-identifiers"><a class="c-article-identifiers__item" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=search&amp;term=Antonio+Gasparrini" data-track="click" data-track-action="author link - pubmed" data-track-label="link">PubMed</a><span class="u-hide">\xa0</span><a class="c-article-identifiers__item" href="http://scholar.google.co.uk/scholar?as_q=&amp;num=10&amp;btnG=Search+Scholar&amp;as_epq=&amp;as_oq=&amp;as_eq=&amp;as_occt=any&amp;as_sauthors=%22Antonio+Gasparrini%22&amp;as_publication=&amp;as_ylo=&amp;as_yhi=&amp;as_allsubj=all&amp;hl=en" data-track="click" data-track-action="author link - scholar" data-track-label="link">Google Scholar</a></span></p>
+                                       </div>
+                                    </div>
+                                 </li>
+                                 <li id="auth-Rachel-Lowe">
+                                    <span class="c-article-authors-search__title u-h3 js-search-name">Rachel Lowe</span>
+                                    <div class="c-article-authors-search__list">
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--left"><a href="/search?author=&#34;Rachel+Lowe&#34;" class="c-article-button" data-track="click" data-track-action="author link - publication" data-track-label="link">View author publications</a></div>
+                                       <div class="c-article-authors-search__item c-article-authors-search__list-item--right">
+                                          <p class="search-in-title-js c-article-authors-search__text">You can also search for this author in\n                        <span class="c-article-identifiers"><a class="c-article-identifiers__item" href="http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?cmd=search&amp;term=Rachel+Lowe" data-track="click" data-track-action="author link - pubmed" data-track-label="link">PubMed</a><span class="u-hide">\xa0</span><a class="c-article-identifiers__item" href="http://scholar.google.co.uk/scholar?as_q=&amp;num=10&amp;btnG=Search+Scholar&amp;as_epq=&amp;as_oq=&amp;as_eq=&amp;as_occt=any&amp;as_sauthors=%22Rachel+Lowe%22&amp;as_publication=&amp;as_ylo=&amp;as_yhi=&amp;as_allsubj=all&amp;hl=en" data-track="click" data-track-action="author link - scholar" data-track-label="link">Google Scholar</a></span></p>
+                                       </div>
+                                    </div>
+                                 </li>
+                              </ol>
+                           </div>
+                           <h3 class="c-article__sub-heading" id="groups">Consortia</h3>
+                           <div class="c-article-author-institutional-author" id="group-1">
+                              <h3 class="c-article-author-institutional-author__name u-h3">MCC Collaborative Research Network</h3>
+                              <ul class="c-article-author-institutional-author__author-list">
+                                 <li class="c-article-author-institutional-author__author-name">Wenbiao Hu</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Shilu Tong</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Eric Lavigne</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Patricia Matus Correa</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Xia Meng</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Haidong Kan</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Jan Kynčl</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Aleš Urban</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Hans Orru</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Niilo R. I. Ryti</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Jouni J. K. Jaakkola</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Simon Cauchemez</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Marco Dallavalle</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Alexandra Schneider</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Ariana Zeka</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Yasushi Honda</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Chris Fook Sheng Ng</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Barrak Alahmad</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Shilpa Rao</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Francesco Di Ruscio</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Gabriel Carrasco-Escobar</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Xerxes Seposo</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Iulian Horia Holobâcă</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Ho Kim</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Whanhee Lee</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Carmen Íñiguez</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Martina S. Ragettli</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Alicia Aleman</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Valentina Colistro</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Michelle L. Bell</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Antonella Zanobetti</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Joel Schwartz</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Tran Ngoc Dang</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Noah Scovronick</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Micheline de Sousa Zanotti Stagliorio Coélho</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Magali Hurtado Diaz</li>
+                                 <li class="c-article-author-institutional-author__author-name">\xa0&amp;\xa0Yuzhou Zhang</li>
+                              </ul>
+                           </div>
+                           <div class="c-article-author-institutional-author" id="group-2">
+                              <h3 class="c-article-author-institutional-author__name u-h3">CMMID COVID-19 Working Group</h3>
+                              <ul class="c-article-author-institutional-author__author-list">
+                                 <li class="c-article-author-institutional-author__author-name">Timothy W. Russell</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Mihaly Koltai</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Adam J. Kucharski</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Rosanna C. Barnard</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Matthew Quaife</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Christopher I. Jarvis</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Jiayao Lei</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0James D. Munday</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Yung-Wai Desmond Chan</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Billy J. Quilty</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Rosalind M. Eggo</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Stefan Flasche</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Anna M. Foss</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Samuel Clifford</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Damien C. Tully</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0W. John Edmunds</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Petra Klepac</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Oliver Brady</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Fabienne Krauer</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Simon R. Procter</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Thibaut Jombart</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Alicia Rosello</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Alicia Showering</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Sebastian Funk</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Joel Hellewell</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Fiona Yueqian Sun</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Akira Endo</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Jack Williams</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Amy Gimma</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Naomi R. Waterlow</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Kiesha Prem</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Nikos I. Bosse</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Hamish P. Gibbs</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Katherine E. Atkins</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Carl A. B. Pearson</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Yalda Jafari</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0C. Julian Villabona-Arenas</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Mark Jit</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Emily S. Nightingale</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Nicholas G. Davies</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Kevin van Zandvoort</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Yang Liu</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Frank G. Sandmann</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0William Waites</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Kaja Abbas</li>
+                                 <li class="c-article-author-institutional-author__author-name">,\xa0Graham Medley</li>
+                                 <li class="c-article-author-institutional-author__author-name">\xa0&amp;\xa0Gwenan M. Knight</li>
+                              </ul>
+                           </div>
+                           <h3 class="c-article__sub-heading" id="contributions">Contributions</h3>
+                           <p>Conceptualisation—ideas; formulation or evolution of overarching research goals and aims: F.S., B.A., S.A., K.O’R., M.H., M.P., A.T., A.M.V.-C., A.G., R.L. Data curation—management activities to annotate (produce metadata), scrub data and maintain research data (including software code, where it is necessary for interpreting the data itself) for initial use and later re-use: F.S., B.A., S.A. and S.M. Formal analysis—application of statistical, mathematical, computational or other formal techniques to analyse or synthesise study data: F.S., B.A. and S.A. Funding acquisition—acquisition of the financial support for the project leading to this publication: AG. Investigation—conducting a research and investigation process, specifically performing the experiments or data/evidence collection: F.S., S.A., S.M., R.L., R.S. and MCC Collaborative Research Network. Methodology—development or design of methodology; creation of models: F.S., B.A., S.A. and A.G. Project administration—management and coordination responsibility for the research activity planning and execution: F.S. and R.L. Resources—provision of study materials, reagents, materials, patients, laboratory samples, animals, instrumentation, computing resources or other analysis tools: A.G. Software—programming, software development; designing computer programmes; implementation of the computer code and supporting algorithms; testing of existing code components: F.S., B.A., S.A. and A.G. Supervision—oversight and leadership responsibility for the research activity planning and execution, including mentorship external to the core team: F.S., B.A. and R.L. Validation—verification, whether as a part of the activity or separate, of the overall replication/reproducibility of results/experiments and other research outputs: F.S. and S.A. Visualisation—preparation, creation and/or presentation of the published work, specifically visualisation/data presentation: F.S., B.A., S.A., R.L. and D.R. Writing—original draft—preparation, creation and/or presentation of the published work, specifically writing the initial draft (including substantive translation): F.S., R.L., B.A. and R.v.B. Writing—review and editing—preparation, creation and/or presentation of the published work by those from the original research group, specifically critical review, commentary or revision—including pre- or post-publication stages: F.S., B.A., S.A., S.M., K.O’R., R.v.B., R.S., D.R., M.H., M.P., A.T., A.M.V.-C., A.G., R.L., MCC Collaborative Research Network and CMMID COVID-19 Working Group.</p>
+                           <h3 class="c-article__sub-heading" id="corresponding-author">Corresponding authors</h3>
+                           <p id="corresponding-author-list">Correspondence to\n                <span>Francesco Sera</span> or <span>Rachel Lowe</span>.</p>
+                        </div>
+                     </div>
+                  </section>
+                  <section data-title="Ethics declarations">
+                     <div class="c-article-section" id="ethics-section">
+                        <h2 class="c-article-section__title js-section-title js-c-reading-companion-sections-item" id="ethics">Ethics declarations</h2>
+                        <div class="c-article-section__content" id="ethics-content">
+                           \n              \n
+                           <h3 class="c-article__sub-heading" id="FPar1">Competing interests</h3>
+                           \n
+                           <p>The authors declare no competing interests.</p>
+                           \n              \n
+                        </div>
+                     </div>
+                  </section>
+                  <section data-title="Additional information">
+                     <div class="c-article-section" id="additional-information-section">
+                        <h2 class="c-article-section__title js-section-title js-c-reading-companion-sections-item" id="additional-information">Additional information</h2>
+                        <div class="c-article-section__content" id="additional-information-content">
+                           <p><b>Peer review information</b> <i>Nature Communications</i> thanks Uriel Kitron, Olivier Restif and the other, anonymous, reviewer(s) for their contribution to the peer review of this work. Peer reviewer reports are available.</p>
+                           <p><b>Publisher’s note</b> Springer Nature remains neutral with regard to jurisdictional claims in published maps and institutional affiliations.</p>
+                        </div>
+                     </div>
+                  </section>
+                  <section data-title="Supplementary information">
+                     <div class="c-article-section" id="Sec12-section">
+                        <h2 class="c-article-section__title js-section-title js-c-reading-companion-sections-item" id="Sec12">Supplementary information</h2>
+                        <div class="c-article-section__content" id="Sec12-content">
+                           <div data-test="supplementary-info">
+                              <div id="figshareContainer" class="c-article-figshare-container" data-test="figshare-container"></div>
+                              \n                  \n                  \n                  \n
+                              <div class="c-article-supplementary__item" data-test="supp-item" id="MOESM1">
+                                 <h3 class="c-article-supplementary__title u-h3"><a class="print-link" data-track="click" data-track-action="view supplementary info" data-track-label="link" data-test="supp-info-link" href="https://static-content.springer.com/esm/art%3A10.1038%2Fs41467-021-25914-8/MediaObjects/41467_2021_25914_MOESM1_ESM.pdf" data-supp-info-image="">Supplementary Information</a></h3>
+                              </div>
+                              <div class="c-article-supplementary__item" data-test="supp-item" id="MOESM2">
+                                 <h3 class="c-article-supplementary__title u-h3"><a class="print-link" data-track="click" data-track-action="view supplementary info" data-track-label="link" data-test="supp-info-link" href="https://static-content.springer.com/esm/art%3A10.1038%2Fs41467-021-25914-8/MediaObjects/41467_2021_25914_MOESM2_ESM.pdf" data-supp-info-image="">Peer Review File</a></h3>
+                              </div>
+                              <div class="c-article-supplementary__item" data-test="supp-item" id="MOESM3">
+                                 <h3 class="c-article-supplementary__title u-h3"><a class="print-link" data-track="click" data-track-action="view supplementary info" data-track-label="link" data-test="supp-info-link" href="https://static-content.springer.com/esm/art%3A10.1038%2Fs41467-021-25914-8/MediaObjects/41467_2021_25914_MOESM3_ESM.pdf" data-supp-info-image="">Reporting Summary</a></h3>
+                              </div>
+                           </div>
+                        </div>
+                     </div>
+                  </section>
+                  <section data-title="Rights and permissions">
+                     <div class="c-article-section" id="rightslink-section">
+                        <h2 class="c-article-section__title js-section-title js-c-reading-companion-sections-item" id="rightslink">Rights and permissions</h2>
+                        <div class="c-article-section__content" id="rightslink-content">
+                           \n
+                           <p><b>Open Access</b>  This article is licensed under a Creative Commons Attribution 4.0 International License, which permits use, sharing, adaptation, distribution and reproduction in any medium or format, as long as you give appropriate credit to the original author(s) and the source, provide a link to the Creative Commons license, and indicate if changes were made. The images or other third party material in this article are included in the article’s Creative Commons license, unless indicated otherwise in a credit line to the material. If material is not included in the article’s Creative Commons license and your intended use is not permitted by statutory regulation or exceeds the permitted use, you will need to obtain permission directly from the copyright holder. To view a copy of this license, visit <a href="http://creativecommons.org/licenses/by/4.0/" rel="license" itemprop="license">http://creativecommons.org/licenses/by/4.0/</a>.</p>
+                           \n
+                           <p class="c-article-rights"><a data-track="click" data-track-action="view rights and permissions" data-track-label="link" href="https://s100.copyright.com/AppDispatchServlet?title=A%20cross-sectional%20analysis%20of%20meteorological%20factors%20and%20SARS-CoV-2%20transmission%20in%20409%20cities%20across%2026%20countries&amp;author=Francesco%20Sera%20Wenbiao%20Hu%20Timothy%20W.%20Russell%20et%20al&amp;contentID=10.1038%2Fs41467-021-25914-8&amp;copyright=The%20Author%28s%29&amp;publication=2041-1723&amp;publicationDate=2021-10-13&amp;publisherName=SpringerNature&amp;orderBeanReset=true&amp;oa=CC%20BY">Reprints and Permissions</a></p>
+                        </div>
+                     </div>
+                  </section>
+                  <section aria-labelledby="article-info" data-title="About this article">
+                     <div class="c-article-section" id="article-info-section">
+                        <h2 class="c-article-section__title js-section-title js-c-reading-companion-sections-item" id="article-info">About this article</h2>
+                        <div class="c-article-section__content" id="article-info-content">
+                           <div class="c-bibliographic-information">
+                              <div class="u-hide-print c-bibliographic-information__column c-bibliographic-information__column--border"><a data-crossmark="10.1038/s41467-021-25914-8" target="_blank" rel="noopener" href="https://crossmark.crossref.org/dialog/?doi=10.1038/s41467-021-25914-8" data-track="click" data-track-action="Click Crossmark" data-track-label="link" data-test="crossmark"><img width="57" height="81" alt="Verify currency and authenticity via CrossMark" src="data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjgxIiB3aWR0aD0iNTciIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGcgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj48cGF0aCBkPSJtMTcuMzUgMzUuNDUgMjEuMy0xNC4ydi0xNy4wM2gtMjEuMyIgZmlsbD0iIzk4OTg5OCIvPjxwYXRoIGQ9Im0zOC42NSAzNS40NS0yMS4zLTE0LjJ2LTE3LjAzaDIxLjMiIGZpbGw9IiM3NDc0NzQiLz48cGF0aCBkPSJtMjggLjVjLTEyLjk4IDAtMjMuNSAxMC41Mi0yMy41IDIzLjVzMTAuNTIgMjMuNSAyMy41IDIzLjUgMjMuNS0xMC41MiAyMy41LTIzLjVjMC02LjIzLTIuNDgtMTIuMjEtNi44OC0xNi42Mi00LjQxLTQuNC0xMC4zOS02Ljg4LTE2LjYyLTYuODh6bTAgNDEuMjVjLTkuOCAwLTE3Ljc1LTcuOTUtMTcuNzUtMTcuNzVzNy45NS0xNy43NSAxNy43NS0xNy43NSAxNy43NSA3Ljk1IDE3Ljc1IDE3Ljc1YzAgNC43MS0xLjg3IDkuMjItNS4yIDEyLjU1cy03Ljg0IDUuMi0xMi41NSA1LjJ6IiBmaWxsPSIjNTM1MzUzIi8+PHBhdGggZD0ibTQxIDM2Yy01LjgxIDYuMjMtMTUuMjMgNy40NS0yMi40MyAyLjktNy4yMS00LjU1LTEwLjE2LTEzLjU3LTcuMDMtMjEuNWwtNC45Mi0zLjExYy00Ljk1IDEwLjctMS4xOSAyMy40MiA4Ljc4IDI5LjcxIDkuOTcgNi4zIDIzLjA3IDQuMjIgMzAuNi00Ljg2eiIgZmlsbD0iIzljOWM5YyIvPjxwYXRoIGQ9Im0uMiA1OC40NWMwLS43NS4xMS0xLjQyLjMzLTIuMDFzLjUyLTEuMDkuOTEtMS41Yy4zOC0uNDEuODMtLjczIDEuMzQtLjk0LjUxLS4yMiAxLjA2LS4zMiAxLjY1LS4zMi41NiAwIDEuMDYuMTEgMS41MS4zNS40NC4yMy44MS41IDEuMS44MWwtLjkxIDEuMDFjLS4yNC0uMjQtLjQ5LS40Mi0uNzUtLjU2LS4yNy0uMTMtLjU4LS4yLS45My0uMi0uMzkgMC0uNzMuMDgtMS4wNS4yMy0uMzEuMTYtLjU4LjM3LS44MS42Ni0uMjMuMjgtLjQxLjYzLS41MyAxLjA0LS4xMy40MS0uMTkuODgtLjE5IDEuMzkgMCAxLjA0LjIzIDEuODYuNjggMi40Ni40NS41OSAxLjA2Ljg4IDEuODQuODguNDEgMCAuNzctLjA3IDEuMDctLjIzcy41OS0uMzkuODUtLjY4bC45MSAxYy0uMzguNDMtLjguNzYtMS4yOC45OS0uNDcuMjItMSAuMzQtMS41OC4zNC0uNTkgMC0xLjEzLS4xLTEuNjQtLjMxLS41LS4yLS45NC0uNTEtMS4zMS0uOTEtLjM4LS40LS42Ny0uOS0uODgtMS40OC0uMjItLjU5LS4zMy0xLjI2LS4zMy0yLjAyem04LjQtNS4zM2gxLjYxdjIuNTRsLS4wNSAxLjMzYy4yOS0uMjcuNjEtLjUxLjk2LS43MnMuNzYtLjMxIDEuMjQtLjMxYy43MyAwIDEuMjcuMjMgMS42MS43MS4zMy40Ny41IDEuMTQuNSAyLjAydjQuMzFoLTEuNjF2LTQuMWMwLS41Ny0uMDgtLjk3LS4yNS0xLjIxLS4xNy0uMjMtLjQ1LS4zNS0uODMtLjM1LS4zIDAtLjU2LjA4LS43OS4yMi0uMjMuMTUtLjQ5LjM2LS43OC42NHY0LjhoLTEuNjF6bTcuMzcgNi40NWMwLS41Ni4wOS0xLjA2LjI2LTEuNTEuMTgtLjQ1LjQyLS44My43MS0xLjE0LjI5LS4zLjYzLS41NCAxLjAxLS43MS4zOS0uMTcuNzgtLjI1IDEuMTgtLjI1LjQ3IDAgLjg4LjA4IDEuMjMuMjQuMzYuMTYuNjUuMzguODkuNjdzLjQyLjYzLjU0IDEuMDNjLjEyLjQxLjE4Ljg0LjE4IDEuMzIgMCAuMzItLjAyLjU3LS4wNy43NmgtNC4zNmMuMDcuNjIuMjkgMS4xLjY1IDEuNDQuMzYuMzMuODIuNSAxLjM4LjUuMjkgMCAuNTctLjA0LjgzLS4xM3MuNTEtLjIxLjc2LS4zN2wuNTUgMS4wMWMtLjMzLjIxLS42OS4zOS0xLjA5LjUzLS40MS4xNC0uODMuMjEtMS4yNi4yMS0uNDggMC0uOTItLjA4LTEuMzQtLjI1LS40MS0uMTYtLjc2LS40LTEuMDctLjctLjMxLS4zMS0uNTUtLjY5LS43Mi0xLjEzLS4xOC0uNDQtLjI2LS45NS0uMjYtMS41MnptNC42LS42MmMwLS41NS0uMTEtLjk4LS4zNC0xLjI4LS4yMy0uMzEtLjU4LS40Ny0xLjA2LS40Ny0uNDEgMC0uNzcuMTUtMS4wNy40NS0uMzEuMjktLjUuNzMtLjU4IDEuM3ptMi41LjYyYzAtLjU3LjA5LTEuMDguMjgtMS41My4xOC0uNDQuNDMtLjgyLjc1LTEuMTNzLjY5LS41NCAxLjEtLjcxYy40Mi0uMTYuODUtLjI0IDEuMzEtLjI0LjQ1IDAgLjg0LjA4IDEuMTcuMjNzLjYxLjM0Ljg1LjU3bC0uNzcgMS4wMmMtLjE5LS4xNi0uMzgtLjI4LS41Ni0uMzctLjE5LS4wOS0uMzktLjE0LS42MS0uMTQtLjU2IDAtMS4wMS4yMS0xLjM1LjYzLS4zNS40MS0uNTIuOTctLjUyIDEuNjcgMCAuNjkuMTcgMS4yNC41MSAxLjY2LjM0LjQxLjc4LjYyIDEuMzIuNjIuMjggMCAuNTQtLjA2Ljc4LS4xNy4yNC0uMTIuNDUtLjI2LjY0LS40MmwuNjcgMS4wM2MtLjMzLjI5LS42OS41MS0xLjA4LjY1LS4zOS4xNS0uNzguMjMtMS4xOC4yMy0uNDYgMC0uOS0uMDgtMS4zMS0uMjQtLjQtLjE2LS43NS0uMzktMS4wNS0uN3MtLjUzLS42OS0uNy0xLjEzYy0uMTctLjQ1LS4yNS0uOTYtLjI1LTEuNTN6bTYuOTEtNi40NWgxLjU4djYuMTdoLjA1bDIuNTQtMy4xNmgxLjc3bC0yLjM1IDIuOCAyLjU5IDQuMDdoLTEuNzVsLTEuNzctMi45OC0xLjA4IDEuMjN2MS43NWgtMS41OHptMTMuNjkgMS4yN2MtLjI1LS4xMS0uNS0uMTctLjc1LS4xNy0uNTggMC0uODcuMzktLjg3IDEuMTZ2Ljc1aDEuMzR2MS4yN2gtMS4zNHY1LjZoLTEuNjF2LTUuNmgtLjkydi0xLjJsLjkyLS4wN3YtLjcyYzAtLjM1LjA0LS42OC4xMy0uOTguMDgtLjMxLjIxLS41Ny40LS43OXMuNDItLjM5LjcxLS41MWMuMjgtLjEyLjYzLS4xOCAxLjA0LS4xOC4yNCAwIC40OC4wMi42OS4wNy4yMi4wNS40MS4xLjU3LjE3em0uNDggNS4xOGMwLS41Ny4wOS0xLjA4LjI3LTEuNTMuMTctLjQ0LjQxLS44Mi43Mi0xLjEzLjMtLjMxLjY1LS41NCAxLjA0LS43MS4zOS0uMTYuOC0uMjQgMS4yMy0uMjRzLjg0LjA4IDEuMjQuMjRjLjQuMTcuNzQuNCAxLjA0Ljcxcy41NC42OS43MiAxLjEzYy4xOS40NS4yOC45Ni4yOCAxLjUzcy0uMDkgMS4wOC0uMjggMS41M2MtLjE4LjQ0LS40Mi44Mi0uNzIgMS4xM3MtLjY0LjU0LTEuMDQuNy0uODEuMjQtMS4yNC4yNC0uODQtLjA4LTEuMjMtLjI0LS43NC0uMzktMS4wNC0uN2MtLjMxLS4zMS0uNTUtLjY5LS43Mi0xLjEzLS4xOC0uNDUtLjI3LS45Ni0uMjctMS41M3ptMS42NSAwYzAgLjY5LjE0IDEuMjQuNDMgMS42Ni4yOC40MS42OC42MiAxLjE4LjYyLjUxIDAgLjktLjIxIDEuMTktLjYyLjI5LS40Mi40NC0uOTcuNDQtMS42NiAwLS43LS4xNS0xLjI2LS40NC0xLjY3LS4yOS0uNDItLjY4LS42My0xLjE5LS42My0uNSAwLS45LjIxLTEuMTguNjMtLjI5LjQxLS40My45Ny0uNDMgMS42N3ptNi40OC0zLjQ0aDEuMzNsLjEyIDEuMjFoLjA1Yy4yNC0uNDQuNTQtLjc5Ljg4LTEuMDIuMzUtLjI0LjctLjM2IDEuMDctLjM2LjMyIDAgLjU5LjA1Ljc4LjE0bC0uMjggMS40LS4zMy0uMDljLS4xMS0uMDEtLjIzLS4wMi0uMzgtLjAyLS4yNyAwLS41Ni4xLS44Ni4zMXMtLjU1LjU4LS43NyAxLjF2NC4yaC0xLjYxem0tNDcuODcgMTVoMS42MXY0LjFjMCAuNTcuMDguOTcuMjUgMS4yLjE3LjI0LjQ0LjM1LjgxLjM1LjMgMCAuNTctLjA3LjgtLjIyLjIyLS4xNS40Ny0uMzkuNzMtLjczdi00LjdoMS42MXY2Ljg3aC0xLjMybC0uMTItMS4wMWgtLjA0Yy0uMy4zNi0uNjMuNjQtLjk4Ljg2LS4zNS4yMS0uNzYuMzItMS4yNC4zMi0uNzMgMC0xLjI3LS4yNC0xLjYxLS43MS0uMzMtLjQ3LS41LTEuMTQtLjUtMi4wMnptOS40NiA3LjQzdjIuMTZoLTEuNjF2LTkuNTloMS4zM2wuMTIuNzJoLjA1Yy4yOS0uMjQuNjEtLjQ1Ljk3LS42My4zNS0uMTcuNzItLjI2IDEuMS0uMjYuNDMgMCAuODEuMDggMS4xNS4yNC4zMy4xNy42MS40Ljg0LjcxLjI0LjMxLjQxLjY4LjUzIDEuMTEuMTMuNDIuMTkuOTEuMTkgMS40NCAwIC41OS0uMDkgMS4xMS0uMjUgMS41Ny0uMTYuNDctLjM4Ljg1LS42NSAxLjE2LS4yNy4zMi0uNTguNTYtLjk0LjczLS4zNS4xNi0uNzIuMjUtMS4xLjI1LS4zIDAtLjYtLjA3LS45LS4ycy0uNTktLjMxLS44Ny0uNTZ6bTAtMi4zYy4yNi4yMi41LjM3LjczLjQ1LjI0LjA5LjQ2LjEzLjY2LjEzLjQ2IDAgLjg0LS4yIDEuMTUtLjYuMzEtLjM5LjQ2LS45OC40Ni0xLjc3IDAtLjY5LS4xMi0xLjIyLS4zNS0xLjYxLS4yMy0uMzgtLjYxLS41Ny0xLjEzLS41Ny0uNDkgMC0uOTkuMjYtMS41Mi43N3ptNS44Ny0xLjY5YzAtLjU2LjA4LTEuMDYuMjUtMS41MS4xNi0uNDUuMzctLjgzLjY1LTEuMTQuMjctLjMuNTgtLjU0LjkzLS43MXMuNzEtLjI1IDEuMDgtLjI1Yy4zOSAwIC43My4wNyAxIC4yLjI3LjE0LjU0LjMyLjgxLjU1bC0uMDYtMS4xdi0yLjQ5aDEuNjF2OS44OGgtMS4zM2wtLjExLS43NGgtLjA2Yy0uMjUuMjUtLjU0LjQ2LS44OC42NC0uMzMuMTgtLjY5LjI3LTEuMDYuMjctLjg3IDAtMS41Ni0uMzItMi4wNy0uOTVzLS43Ni0xLjUxLS43Ni0yLjY1em0xLjY3LS4wMWMwIC43NC4xMyAxLjMxLjQgMS43LjI2LjM4LjY1LjU4IDEuMTUuNTguNTEgMCAuOTktLjI2IDEuNDQtLjc3di0zLjIxYy0uMjQtLjIxLS40OC0uMzYtLjctLjQ1LS4yMy0uMDgtLjQ2LS4xMi0uNy0uMTItLjQ1IDAtLjgyLjE5LTEuMTMuNTktLjMxLjM5LS40Ni45NS0uNDYgMS42OHptNi4zNSAxLjU5YzAtLjczLjMyLTEuMy45Ny0xLjcxLjY0LS40IDEuNjctLjY4IDMuMDgtLjg0IDAtLjE3LS4wMi0uMzQtLjA3LS41MS0uMDUtLjE2LS4xMi0uMy0uMjItLjQzcy0uMjItLjIyLS4zOC0uM2MtLjE1LS4wNi0uMzQtLjEtLjU4LS4xLS4zNCAwLS42OC4wNy0xIC4ycy0uNjMuMjktLjkzLjQ3bC0uNTktMS4wOGMuMzktLjI0LjgxLS40NSAxLjI4LS42My40Ny0uMTcuOTktLjI2IDEuNTQtLjI2Ljg2IDAgMS41MS4yNSAxLjkzLjc2cy42MyAxLjI1LjYzIDIuMjF2NC4wN2gtMS4zMmwtLjEyLS43NmgtLjA1Yy0uMy4yNy0uNjMuNDgtLjk4LjY2cy0uNzMuMjctMS4xNC4yN2MtLjYxIDAtMS4xLS4xOS0xLjQ4LS41Ni0uMzgtLjM2LS41Ny0uODUtLjU3LTEuNDZ6bTEuNTctLjEyYzAgLjMuMDkuNTMuMjcuNjcuMTkuMTQuNDIuMjEuNzEuMjEuMjggMCAuNTQtLjA3Ljc3LS4ycy40OC0uMzEuNzMtLjU2di0xLjU0Yy0uNDcuMDYtLjg2LjEzLTEuMTguMjMtLjMxLjA5LS41Ny4xOS0uNzYuMzFzLS4zMy4yNS0uNDEuNGMtLjA5LjE1LS4xMy4zMS0uMTMuNDh6bTYuMjktMy42M2gtLjk4di0xLjJsMS4wNi0uMDcuMi0xLjg4aDEuMzR2MS44OGgxLjc1djEuMjdoLTEuNzV2My4yOGMwIC44LjMyIDEuMi45NyAxLjIuMTIgMCAuMjQtLjAxLjM3LS4wNC4xMi0uMDMuMjQtLjA3LjM0LS4xMWwuMjggMS4xOWMtLjE5LjA2LS40LjEyLS42NC4xNy0uMjMuMDUtLjQ5LjA4LS43Ni4wOC0uNCAwLS43NC0uMDYtMS4wMi0uMTgtLjI3LS4xMy0uNDktLjMtLjY3LS41Mi0uMTctLjIxLS4zLS40OC0uMzctLjc4LS4wOC0uMy0uMTItLjY0LS4xMi0xLjAxem00LjM2IDIuMTdjMC0uNTYuMDktMS4wNi4yNy0xLjUxcy40MS0uODMuNzEtMS4xNGMuMjktLjMuNjMtLjU0IDEuMDEtLjcxLjM5LS4xNy43OC0uMjUgMS4xOC0uMjUuNDcgMCAuODguMDggMS4yMy4yNC4zNi4xNi42NS4zOC44OS42N3MuNDIuNjMuNTQgMS4wM2MuMTIuNDEuMTguODQuMTggMS4zMiAwIC4zMi0uMDIuNTctLjA3Ljc2aC00LjM3Yy4wOC42Mi4yOSAxLjEuNjUgMS40NC4zNi4zMy44Mi41IDEuMzguNS4zIDAgLjU4LS4wNC44NC0uMTMuMjUtLjA5LjUxLS4yMS43Ni0uMzdsLjU0IDEuMDFjLS4zMi4yMS0uNjkuMzktMS4wOS41M3MtLjgyLjIxLTEuMjYuMjFjLS40NyAwLS45Mi0uMDgtMS4zMy0uMjUtLjQxLS4xNi0uNzctLjQtMS4wOC0uNy0uMy0uMzEtLjU0LS42OS0uNzItMS4xMy0uMTctLjQ0LS4yNi0uOTUtLjI2LTEuNTJ6bTQuNjEtLjYyYzAtLjU1LS4xMS0uOTgtLjM0LTEuMjgtLjIzLS4zMS0uNTgtLjQ3LTEuMDYtLjQ3LS40MSAwLS43Ny4xNS0xLjA4LjQ1LS4zMS4yOS0uNS43My0uNTcgMS4zem0zLjAxIDIuMjNjLjMxLjI0LjYxLjQzLjkyLjU3LjMuMTMuNjMuMi45OC4yLjM4IDAgLjY1LS4wOC44My0uMjNzLjI3LS4zNS4yNy0uNmMwLS4xNC0uMDUtLjI2LS4xMy0uMzctLjA4LS4xLS4yLS4yLS4zNC0uMjgtLjE0LS4wOS0uMjktLjE2LS40Ny0uMjNsLS41My0uMjJjLS4yMy0uMDktLjQ2LS4xOC0uNjktLjMtLjIzLS4xMS0uNDQtLjI0LS42Mi0uNHMtLjMzLS4zNS0uNDUtLjU1Yy0uMTItLjIxLS4xOC0uNDYtLjE4LS43NSAwLS42MS4yMy0xLjEuNjgtMS40OS40NC0uMzggMS4wNi0uNTcgMS44My0uNTcuNDggMCAuOTEuMDggMS4yOS4yNXMuNzEuMzYuOTkuNTdsLS43NC45OGMtLjI0LS4xNy0uNDktLjMyLS43My0uNDItLjI1LS4xMS0uNTEtLjE2LS43OC0uMTYtLjM1IDAtLjYuMDctLjc2LjIxLS4xNy4xNS0uMjUuMzMtLjI1LjU0IDAgLjE0LjA0LjI2LjEyLjM2cy4xOC4xOC4zMS4yNmMuMTQuMDcuMjkuMTQuNDYuMjFsLjU0LjE5Yy4yMy4wOS40Ny4xOC43LjI5cy40NC4yNC42NC40Yy4xOS4xNi4zNC4zNS40Ni41OC4xMS4yMy4xNy41LjE3LjgyIDAgLjMtLjA2LjU4LS4xNy44My0uMTIuMjYtLjI5LjQ4LS41MS42OC0uMjMuMTktLjUxLjM0LS44NC40NS0uMzQuMTEtLjcyLjE3LTEuMTUuMTctLjQ4IDAtLjk1LS4wOS0xLjQxLS4yNy0uNDYtLjE5LS44Ni0uNDEtMS4yLS42OHoiIGZpbGw9IiM1MzUzNTMiLz48L2c+PC9zdmc+" /></a></div>
+                              <div class="c-bibliographic-information__column">
+                                 <h3 class="c-article__sub-heading" id="citeas">Cite this article</h3>
+                                 <p class="c-bibliographic-information__citation">Sera, F., Armstrong, B., Abbott, S. <i>et al.</i> A cross-sectional analysis of meteorological factors and SARS-CoV-2 transmission in 409 cities across 26 countries.\n                    <i>Nat Commun</i> <b>12, </b>5968 (2021). https://doi.org/10.1038/s41467-021-25914-8</p>
+                                 <p class="c-bibliographic-information__download-citation u-hide-print">
+                                    <a data-test="citation-link" data-track="click" data-track-action="download article citation" data-track-label="link" data-track-external="" href="https://citation-needed.springer.com/v2/references/10.1038/s41467-021-25914-8?format=refman&amp;flavour=citation">
+                                       Download citation
+                                       <svg width="16" height="16" focusable="false" role="img" aria-hidden="true" class="u-icon">
+                                          <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#global-icon-download"></use>
+                                       </svg>
+                                    </a>
+                                 </p>
+                                 <ul class="c-bibliographic-information__list" data-test="publication-history">
+                                    <li class="c-bibliographic-information__list-item">
+                                       <p>Received<span class="u-hide">: </span><span class="c-bibliographic-information__value"><time datetime="2021-02-18">18 February 2021</time></span></p>
+                                    </li>
+                                    <li class="c-bibliographic-information__list-item">
+                                       <p>Accepted<span class="u-hide">: </span><span class="c-bibliographic-information__value"><time datetime="2021-09-08">08 September 2021</time></span></p>
+                                    </li>
+                                    <li class="c-bibliographic-information__list-item">
+                                       <p>Published<span class="u-hide">: </span><span class="c-bibliographic-information__value"><time datetime="2021-10-13">13 October 2021</time></span></p>
+                                    </li>
+                                    <li class="c-bibliographic-information__list-item c-bibliographic-information__list-item--doi">
+                                       <p><abbr title="Digital Object Identifier">DOI</abbr><span class="u-hide">: </span><span class="c-bibliographic-information__value"><a href="https://doi.org/10.1038/s41467-021-25914-8" data-track="click" data-track-action="view doi" data-track-label="link">https://doi.org/10.1038/s41467-021-25914-8</a></span></p>
+                                    </li>
+                                 </ul>
+                                 <div data-component="share-box">
+                                    <div class="c-article-share-box u-display-none" hidden="">
+                                       <h3 class="c-article__sub-heading">Share this article</h3>
+                                       <p class="c-article-share-box__description">Anyone you share the following link with will be able to read this content:</p>
+                                       <button class="js-get-share-url c-article-share-box__button" id="get-share-url" data-track="click" data-track-label="button" data-track-external="" data-track-action="get shareable link">Get shareable link</button>
+                                       <div class="js-no-share-url-container u-display-none" hidden="">
+                                          <p class="js-c-article-share-box__no-sharelink-info c-article-share-box__no-sharelink-info">Sorry, a shareable link is not currently available for this article.</p>
+                                       </div>
+                                       <div class="js-share-url-container u-display-none" hidden="">
+                                          <p class="js-share-url c-article-share-box__only-read-input" id="share-url" data-track="click" data-track-label="button" data-track-action="select share url"></p>
+                                          <button class="js-copy-share-url c-article-share-box__button--link-like" id="copy-share-url" data-track="click" data-track-label="button" data-track-action="copy share url" data-track-external="">Copy to clipboard</button>
+                                       </div>
+                                       <p class="js-c-article-share-box__additional-info c-article-share-box__additional-info">\n                            Provided by the Springer Nature SharedIt content-sharing initiative\n                        </p>
+                                    </div>
+                                 </div>
+                                 <div data-component="article-info-list"></div>
+                              </div>
+                           </div>
+                        </div>
+                     </div>
+                  </section>
+                  \n\n            \n\n            \n
+                  <section data-title="Comments">
+                     <div class="c-article-section" id="article-comments-section">
+                        <h2 class="c-article-section__title js-section-title js-c-reading-companion-sections-item" id="article-comments">Comments</h2>
+                        <div class="c-article-section__content" id="article-comments-content">
+                           <p>By submitting a comment you agree to abide by our <a href="/info/tandc.html">Terms</a> and <a href="/info/community-guidelines.html">Community Guidelines</a>. If you find something abusive or that does not comply with our terms or guidelines please flag it as inappropriate.</p>
+                        </div>
+                     </div>
+                  </section>
+                  \n
+                  <div id="inject-comments">
+                     \n
+                     <div class="placeholder" data-replace="true"\n                         data-disqus-placeholder="/platform/disqus?doi=10.1038/s41467-021-25914-8 #article-comments-container">\n                </div>
+                     \n
+                  </div>
+                  \n            \n\n            <span data-recommended="jobs"></span>\n
+               </div>
+               \n
+            </article>
+            \n
+         </main>
+         \n\n
+         <aside class="c-article-extras u-hide-print" aria-label="Article navigation" data-component-reading-companion data-container-type="reading-companion" data-track-component="reading companion">
+            \n    \n            \n            \n    \n
+            <div class="c-pdf-download u-clear-both">
+               \n
+               <a href="/articles/s41467-021-25914-8.pdf" class="c-pdf-download__link" data-article-pdf="true" data-readcube-pdf-url="true" data-test="download-pdf" data-draft-ignore="true" data-track="click" data-track-action="download pdf" data-track-label="link" data-track-external>
+                  \n            <span>Download PDF</span>\n
+                  <svg aria-hidden="true" focusable="false" width="16" height="16" class="u-icon">
+                     <use xlink:href="#global-icon-download"/>
+                  </svg>
+                  \n
+               </a>
+               \n
+            </div>
+            \n    \n\n        \n    \n\n    \n\n    \n        \n    \n\n    \n\n
+            <div class="c-reading-companion">
+               \n
+               <div class="c-reading-companion__sticky" data-component="reading-companion-sticky" data-test="reading-companion-sticky">
+                  \n
+                  <div class="c-reading-companion__panel c-reading-companion__sections c-reading-companion__panel--active" id="tabpanel-sections">
+                     \n
+                     <div class="u-mt-16" data-component-mpu>
+                        \n
+                        <div class="c-ad c-ad--300x250">
+                           \n
+                           <div class="c-ad__inner">
+                              \n
+                              <p class="c-ad__label">Advertisement</p>
+                              \n                            \n    <div id="div-gpt-ad-right-2"\n         class="div-gpt-ad advert medium-rectangle js-ad text-center hide-print grade-c-hide"\n         data-ad-type="right"\n         data-pa11y-ignore\n         data-gpt\n         data-gpt-unitpath="/285/nature_communications/article"\n         data-gpt-sizes="300x250"\n         data-gpt-targeting="type=article;pos=right;artid=s41467-021-25914-8;doi=10.1038/s41467-021-25914-8;techmeta=129,141;subjmeta=106,174,308,326,4130,499,596,631,692,704;kwrd=Climate sciences,Epidemiology,Risk factors,SARS-CoV-2">\n
+                              <noscript>\n            <a href="//pubads.g.doubleclick.net/gampad/jump?iu=/285/nature_communications/article&amp;sz=300x250&amp;c=616292713&amp;t=pos%3Dright%26type%3Darticle%26artid%3Ds41467-021-25914-8%26doi%3D10.1038/s41467-021-25914-8%26techmeta%3D129,141%26subjmeta%3D106,174,308,326,4130,499,596,631,692,704%26kwrd%3DClimate sciences,Epidemiology,Risk factors,SARS-CoV-2">\n                <img data-test="gpt-advert-fallback-img"\n                     src="//pubads.g.doubleclick.net/gampad/ad?iu=/285/nature_communications/article&amp;sz=300x250&amp;c=616292713&amp;t=pos%3Dright%26type%3Darticle%26artid%3Ds41467-021-25914-8%26doi%3D10.1038/s41467-021-25914-8%26techmeta%3D129,141%26subjmeta%3D106,174,308,326,4130,499,596,631,692,704%26kwrd%3DClimate sciences,Epidemiology,Risk factors,SARS-CoV-2"\n                     alt="Advertisement"\n                     width="300"\n                     height="250"></a>\n        </noscript>
+                              \n
+                           </div>
+                           \n\n
+                        </div>
+                        \n
+                     </div>
+                     \n
+                  </div>
+                  \n
+               </div>
+               \n
+               <div class="c-reading-companion__panel c-reading-companion__figures c-reading-companion__panel--full-width" id="tabpanel-figures"></div>
+               \n
+               <div class="c-reading-companion__panel c-reading-companion__references c-reading-companion__panel--full-width" id="tabpanel-references"></div>
+               \n
+            </div>
+            \n
+      </div>
+      \n</aside>\n</div>\n\n\n    \n
+      <nav class="u-hide-print c-header-expander" aria-labelledby="Explore-content" data-test="Explore-content" id="explore" data-track-component="nature-150-split-header">
+         \n
+         <div class="c-header-expander__container">
+            \n
+            <h2 id="Explore-content" class="c-header-expander__heading u-js-hide">Explore content</h2>
+            \n
+            <ul class="c-header-expander__list">
+               \n                    \n                        \n
+               <li class="c-header-expander__item">\n                                <a class="c-header-expander__link"\n                                   href="/ncomms/research-articles"\n                                   data-track="click"\n                                   data-track-action="research articles"\n                                   data-track-label="link"\n                                   data-test="explore-nav-item">\n                                    Research articles\n                                </a>\n                            </li>
+               \n                        \n
+               <li class="c-header-expander__item">\n                                <a class="c-header-expander__link"\n                                   href="/ncomms/reviews-and-analysis"\n                                   data-track="click"\n                                   data-track-action="reviews &amp; analysis"\n                                   data-track-label="link"\n                                   data-test="explore-nav-item">\n                                    Reviews &amp; Analysis\n                                </a>\n                            </li>
+               \n                        \n
+               <li class="c-header-expander__item">\n                                <a class="c-header-expander__link"\n                                   href="/ncomms/news-and-comment"\n                                   data-track="click"\n                                   data-track-action="news &amp; comment"\n                                   data-track-label="link"\n                                   data-test="explore-nav-item">\n                                    News &amp; Comment\n                                </a>\n                            </li>
+               \n                        \n
+               <li class="c-header-expander__item">\n                                <a class="c-header-expander__link"\n                                   href="/ncomms/video"\n                                   data-track="click"\n                                   data-track-action="videos"\n                                   data-track-label="link"\n                                   data-test="explore-nav-item">\n                                    Videos\n                                </a>\n                            </li>
+               \n                        \n
+               <li class="c-header-expander__item">\n                                <a class="c-header-expander__link"\n                                   href="/ncomms/collections"\n                                   data-track="click"\n                                   data-track-action="collections"\n                                   data-track-label="link"\n                                   data-test="explore-nav-item">\n                                    Collections\n                                </a>\n                            </li>
+               \n                        \n
+               <li class="c-header-expander__item">\n                                <a class="c-header-expander__link"\n                                   href="/ncomms/browse-subjects"\n                                   data-track="click"\n                                   data-track-action="subjects"\n                                   data-track-label="link"\n                                   data-test="explore-nav-item">\n                                    Subjects\n                                </a>\n                            </li>
+               \n                        \n                    \n                    \n
+               <li class="c-header-expander__item c-header-expander__item--keyline c-header-expander__item--keyline-first-item-only">\n                            <a class="c-header-expander__link"\n                               href="https://www.facebook.com/NatureCommunications"\n                               data-track="click"\n                               data-track-action="facebook"\n                               data-track-label="link">Follow us on Facebook\n                            </a>\n                        </li>
+               \n                    \n                    \n
+               <li class="c-header-expander__item c-header-expander__item--keyline c-header-expander__item--keyline-first-item-only">\n                            <a class="c-header-expander__link"\n                               href="https://twitter.com/NatureComms"\n                               data-track="click"\n                               data-track-action="twitter"\n                               data-track-label="link">Follow us on Twitter\n                            </a>\n                        </li>
+               \n                    \n                    \n                    \n
+               <li class="c-header-expander__item c-header-expander__item--keyline c-header-expander__item--keyline-first-item-only u-hide-at-lg">
+                  \n                            <a class="c-header-expander__link"\n                               href="https://www.nature.com/my-account/alerts/subscribe-journal?list-id&#x3D;264"\n                               rel="nofollow"\n                               data-track="click"\n                               data-track-action="Sign up for alerts"\n                               data-track-external\n                               data-track-label="link (mobile dropdown)">Sign up for alerts
+                  <svg role="img" aria-hidden="true" focusable="false" height="18" viewBox="0 0 18 18" width="18" xmlns="http://www.w3.org/2000/svg">
+                     <path d="m4 10h2.5c.27614237 0 .5.2238576.5.5s-.22385763.5-.5.5h-3.08578644l-1.12132034 1.1213203c-.18753638.1875364-.29289322.4418903-.29289322.7071068v.1715729h14v-.1715729c0-.2652165-.1053568-.5195704-.2928932-.7071068l-1.7071068-1.7071067v-3.4142136c0-2.76142375-2.2385763-5-5-5-2.76142375 0-5 2.23857625-5 5zm3 4c0 1.1045695.8954305 2 2 2s2-.8954305 2-2zm-5 0c-.55228475 0-1-.4477153-1-1v-.1715729c0-.530433.21071368-1.0391408.58578644-1.4142135l1.41421356-1.4142136v-3c0-3.3137085 2.6862915-6 6-6s6 2.6862915 6 6v3l1.4142136 1.4142136c.3750727.3750727.5857864.8837805.5857864 1.4142135v.1715729c0 .5522847-.4477153 1-1 1h-4c0 1.6568542-1.3431458 3-3 3-1.65685425 0-3-1.3431458-3-3z" fill="#fff"/>
+                  </svg>
+                  \n                            </a>\n
+               </li>
+               \n                    \n                    \n
+               <li class="c-header-expander__item c-header-expander__item--keyline c-header-expander__item--keyline-first-item-only u-hide-at-lg">\n                            <a class="c-header-expander__link"\n                               href="http://feeds.nature.com/ncomms/rss/current"\n                               data-track="click"\n                               data-track-action="rss feed"\n                               data-track-label="link">\n                                <span>RSS feed</span>\n                            </a>\n                        </li>
+               \n                    \n
+            </ul>
+            \n
+         </div>
+         \n
+      </nav>
+      \n    \n\n    \n
+      <nav class="u-hide-print c-header-expander" aria-labelledby="About-the-journal" id="about-the-journal" data-track-component="nature-150-split-header">
+         \n
+         <div class="c-header-expander__container">
+            \n
+            <h2 id="About-the-journal" class="c-header-expander__heading u-js-hide">About the journal</h2>
+            \n
+            <ul class="c-header-expander__list">
+               \n                    \n
+               <li class="c-header-expander__item">\n                            <a class="c-header-expander__link"\n                               href="/ncomms/aims"\n                               data-track="click"\n                               data-track-action="aims &amp; scope"\n                               data-track-label="link">\n                                Aims &amp; Scope\n                            </a>\n                        </li>
+               \n                    \n
+               <li class="c-header-expander__item">\n                            <a class="c-header-expander__link"\n                               href="/ncomms/editors"\n                               data-track="click"\n                               data-track-action="editors"\n                               data-track-label="link">\n                                Editors\n                            </a>\n                        </li>
+               \n                    \n
+               <li class="c-header-expander__item">\n                            <a class="c-header-expander__link"\n                               href="/ncomms/journal-information"\n                               data-track="click"\n                               data-track-action="journal information"\n                               data-track-label="link">\n                                Journal Information\n                            </a>\n                        </li>
+               \n                    \n
+               <li class="c-header-expander__item">\n                            <a class="c-header-expander__link"\n                               href="/ncomms/open-access"\n                               data-track="click"\n                               data-track-action="open access"\n                               data-track-label="link">\n                                Open access\n                            </a>\n                        </li>
+               \n                    \n
+               <li class="c-header-expander__item">\n                            <a class="c-header-expander__link"\n                               href="/ncomms/article-processing-charges"\n                               data-track="click"\n                               data-track-action="article processing charges"\n                               data-track-label="link">\n                                Article processing charges\n                            </a>\n                        </li>
+               \n                    \n
+               <li class="c-header-expander__item">\n                            <a class="c-header-expander__link"\n                               href="/ncomms/editorial-values-statement"\n                               data-track="click"\n                               data-track-action="editorial values statement"\n                               data-track-label="link">\n                                Editorial Values Statement\n                            </a>\n                        </li>
+               \n                    \n
+               <li class="c-header-expander__item">\n                            <a class="c-header-expander__link"\n                               href="/ncomms/journal-impact"\n                               data-track="click"\n                               data-track-action="journal impact"\n                               data-track-label="link">\n                                Journal Impact\n                            </a>\n                        </li>
+               \n                    \n
+               <li class="c-header-expander__item">\n                            <a class="c-header-expander__link"\n                               href="/ncomms/editorshighlights"\n                               data-track="click"\n                               data-track-action="editors&#x27; highlights"\n                               data-track-label="link">\n                                Editors&#x27; Highlights\n                            </a>\n                        </li>
+               \n                    \n
+               <li class="c-header-expander__item">\n                            <a class="c-header-expander__link"\n                               href="/ncomms/contact"\n                               data-track="click"\n                               data-track-action="contact"\n                               data-track-label="link">\n                                Contact\n                            </a>\n                        </li>
+               \n                    \n
+               <li class="c-header-expander__item">\n                            <a class="c-header-expander__link"\n                               href="/ncomms/top50"\n                               data-track="click"\n                               data-track-action="top 50 articles"\n                               data-track-label="link">\n                                Top 50 Articles\n                            </a>\n                        </li>
+               \n                    \n
+               <li class="c-header-expander__item">\n                            <a class="c-header-expander__link"\n                               href="/ncomms/editorial-policies"\n                               data-track="click"\n                               data-track-action="editorial policies"\n                               data-track-label="link">\n                                Editorial policies\n                            </a>\n                        </li>
+               \n                    \n
+            </ul>
+            \n
+         </div>
+         \n
+      </nav>
+      \n    \n\n    \n
+      <nav class="u-hide-print c-header-expander" aria-labelledby="Publish-with-us-label" id="publish-with-us" data-track-component="nature-150-split-header">
+         \n
+         <div class="c-header-expander__container">
+            \n
+            <h2 id="Publish-with-us-label" class="c-header-expander__heading u-js-hide">Publish with us</h2>
+            \n
+            <ul class="c-header-expander__list">
+               \n                    \n
+               <li class="c-header-expander__item">\n                            <a class="c-header-expander__link"\n                               href="/ncomms/submit"\n                               data-track="click"\n                               data-track-action="for authors"\n                               data-track-label="link">\n                                For authors\n                            </a>\n                        </li>
+               \n                    \n
+               <li class="c-header-expander__item">\n                            <a class="c-header-expander__link"\n                               href="/ncomms/for-reviewers"\n                               data-track="click"\n                               data-track-action="for reviewers"\n                               data-track-label="link">\n                                For Reviewers\n                            </a>\n                        </li>
+               \n                    \n                    \n
+               <li class="c-header-expander__item c-header-expander__item--keyline">
+                  \n                            <a class="c-header-expander__link"\n                               href="https://mts-ncomms.nature.com/"\n                               data-track="click"\n                               data-track-action="Submit manuscript"\n                               data-track-label="link"\n                               data-track-external>Submit manuscript
+                  <svg role="img" aria-hidden="true" focusable="false" height="18" viewBox="0 0 18 18" width="18" xmlns="http://www.w3.org/2000/svg">
+                     <path d="m15 0c1.1045695 0 2 .8954305 2 2v5.5c0 .27614237-.2238576.5-.5.5s-.5-.22385763-.5-.5v-5.5c0-.51283584-.3860402-.93550716-.8833789-.99327227l-.1166211-.00672773h-9v3c0 1.1045695-.8954305 2-2 2h-3v10c0 .5128358.38604019.9355072.88337887.9932723l.11662113.0067277h7.5c.27614237 0 .5.2238576.5.5s-.22385763.5-.5.5h-7.5c-1.1045695 0-2-.8954305-2-2v-10.17157288c0-.53043297.21071368-1.0391408.58578644-1.41421356l3.82842712-3.82842712c.37507276-.37507276.88378059-.58578644 1.41421356-.58578644zm-.5442863 8.18867991 3.3545404 3.35454039c.2508994.2508994.2538696.6596433.0035959.909917-.2429543.2429542-.6561449.2462671-.9065387-.0089489l-2.2609825-2.3045251.0010427 7.2231989c0 .3569916-.2898381.6371378-.6473715.6371378-.3470771 0-.6473715-.2852563-.6473715-.6371378l-.0010428-7.2231995-2.2611222 2.3046654c-.2531661.2580415-.6562868.2592444-.9065605.0089707-.24295423-.2429542-.24865597-.6576651.0036132-.9099343l3.3546673-3.35466731c.2509089-.25090888.6612706-.25227691.9135302-.00001728zm-.9557137-3.18867991c.2761424 0 .5.22385763.5.5s-.2238576.5-.5.5h-6c-.27614237 0-.5-.22385763-.5-.5s.22385763-.5.5-.5zm-8.5-3.587-3.587 3.587h2.587c.55228475 0 1-.44771525 1-1zm8.5 1.587c.2761424 0 .5.22385763.5.5s-.2238576.5-.5.5h-6c-.27614237 0-.5-.22385763-.5-.5s.22385763-.5.5-.5z" fill="#fff"/>
+                  </svg>
+                  \n                            </a>\n
+               </li>
+               \n                    \n
+            </ul>
+            \n
+         </div>
+         \n
+      </nav>
+      \n    \n\n\n
+      <div id="search-menu" class="c-header-expander c-header-expander--tray u-hide-print" data-track-component="nature-150-split-header">
+         \n
+         <div class="c-header-expander__container">
+            \n
+            <h2 class="u-visually-hidden">Search</h2>
+            \n
+            <div data-test="inline-search">
+               \n
+               <div class="c-search c-search--max-width u-mb-16">
+                  \n                <form action="/search"\n                      method="get"\n                      role="search"\n                      autocomplete="off"\n                      data-dynamic-track-label\n                      data-track="submit" data-track-action="search" data-track-label="form">\n                    <label class="c-header-expander__heading u-mb-8" for="keywords">Search articles by subject, keyword or author</label>\n
+                  <div class="c-search__field">
+                     \n
+                     <div class="c-search__input-container c-search__input-container--md">\n                            <input type="text"\n                               required\n                               class="c-search__input"\n                               id="keywords"\n                               name="q"\n                               value=""\n                               data-test="search-keywords">\n                        </div>
+                     \n\n
+                     <div class="c-search__select-container">
+                        \n                            <label for="results-from" class="u-visually-hidden">Show results from</label>\n
+                        <select id="results-from" name="journal" class="c-search__select">
+                           \n                                \n                                    \n
+                           <option value="" selected>All journals</option>
+                           \n
+                           <option value="ncomms">This journal</option>
+                           \n                                    \n                                \n
+                        </select>
+                        \n
+                     </div>
+                     \n
+                     <div class="c-search__button-container">\n                            <button type="submit" class="u-button u-button--primary u-button--full-width" data-test="search-submit">Search</button>\n                        </div>
+                     \n
+                  </div>
+                  \n                </form>\n
+               </div>
+               \n
+            </div>
+            \n\n
+            <div class="c-header-expander__keyline u-mb-16">
+               \n
+               <p class="u-ma-0">\n                <a href="/search/advanced"\n                   data-track="click" data-track-action="advanced search" data-track-label="link">\n                    Advanced search\n                </a>\n            </p>
+               \n
+            </div>
+            \n
+            <h3 class="c-header-expander__heading">Quick links</h3>
+            \n
+            <ul class="u-list-reset">
+               \n
+               <li class="u-display-inline-block u-mr-24 u-mb-16"><a href="/subjects" data-track="click" data-track-action="explore articles by subject" data-track-label="link">Explore articles by subject</a></li>
+               \n
+               <li class="u-display-inline-block u-mr-24 u-mb-16"><a href="/naturecareers" data-track="click" data-track-action="find a job" data-track-label="link">Find a job</a></li>
+               \n
+               <li class="u-display-inline-block u-mr-24 u-mb-16"><a href="/authors/index.html" data-track="click" data-track-action="guide to authors" data-track-label="link">Guide to authors</a></li>
+               \n
+               <li class="u-display-inline-block u-mr-24 u-mb-16"><a href="/authors/editorial_policies/" data-track="click" data-track-action="editorial policies" data-track-label="link">Editorial policies</a></li>
+               \n
+            </ul>
+            \n
+         </div>
+         \n
+      </div>
+      \n\n
+      <footer role="contentinfo" class="composite-layer">
+         \n    \n
+         <div class="u-mt-16 u-mb-16">
+            \n
+            <div class="u-container">
+               \n
+               <div class="u-display-flex u-flex-wrap u-justify-content-space-between">
+                  \n            \n\n
+                  <p class="c-meta u-ma-0 u-flex-shrink">\n                <span class="c-meta__item">\n                    Nature Communications (<i>Nat Commun</i>)\n                </span>\n                \n    \n    <span class="c-meta__item">\n        <abbr title="International Standard Serial Number">ISSN</abbr> <span itemprop="onlineIssn">2041-1723</span> (online)\n    </span>\n    \n\n\n                \n    \n\n            </p>
+                  \n
+               </div>
+               \n
+            </div>
+            \n
+         </div>
+         \n\n\n
+         <div itemscope itemtype="http://schema.org/Periodical">
+            \n
+            <meta itemprop="publisher" content="Springer Nature">
+            \n
+            <div class="c-footer">
+               \n
+               <div class="u-container">
+                  \n
+                  <div class="u-hide-print" data-track-component="footer">
+                     \n
+                     <h2 aria-level="2" class="u-visually-hidden">nature.com sitemap</h2>
+                     \n
+                     <div class="c-footer__header">
+                        \n
+                        <div class="c-footer__logo">\n            <img alt="Nature portfolio" src="/static/images/logos/nature-portfolio-white.7caca87447.svg" loading="lazy" width="200" height="31">\n        </div>
+                        \n
+                        <ul class="c-menu c-menu--inherit u-mr-32">
+                           \n
+                           <li class="c-menu__item"><a class="c-menu__link" href="https://www.nature.com/npg_/company_info/index.html" data-track="click" data-track-action="about us" data-track-label="link">About us</a></li>
+                           \n
+                           <li class="c-menu__item"><a class="c-menu__link" href="https://www.nature.com/npg_/press_room/press_releases.html" data-track="click" data-track-action="press releases" data-track-label="link">Press releases</a></li>
+                           \n
+                           <li class="c-menu__item"><a class="c-menu__link" href="https://press.nature.com/" data-track="click" data-track-action="press office" data-track-label="link">Press office</a></li>
+                           \n
+                           <li class="c-menu__item"><a class="c-menu__link" href="https://support.nature.com/support/home" data-track="click" data-track-action="contact us" data-track-label="link">Contact us</a></li>
+                           \n
+                        </ul>
+                        \n
+                        <ul class="c-menu c-menu--inherit">
+                           \n
+                           <li class="c-menu__item">
+                              \n
+                              <a class="c-menu__link" href="https://www.facebook.com/nature/" aria-label="Facebook" data-track="click" data-track-action="facebook" data-track-label="link">
+                                 \n
+                                 <svg class="u-icon u-mt-2 u-mb-2" role="img" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 20 20">
+                                    <path d="M2.5 20C1.1 20 0 18.9 0 17.5v-15C0 1.1 1.1 0 2.5 0h15C18.9 0 20 1.1 20 2.5v15c0 1.4-1.1 2.5-2.5 2.5h-3.7v-7.7h2.6l.4-3h-3v-2c0-.9.2-1.5 1.5-1.5h1.6V3.1c-.3 0-1.2-.1-2.3-.1-2.3 0-3.9 1.4-3.9 4v2.2H8.1v3h2.6V20H2.5z"/>
+                                 </svg>
+                                 \n
+                              </a>
+                              \n
+                           </li>
+                           \n
+                           <li class="c-menu__item">
+                              \n
+                              <a class="c-menu__link" href="https://twitter.com/NaturePortfolio?lang=en" aria-label="Twitter" data-track="click" data-track-action="twitter" data-track-label="link">
+                                 \n
+                                 <svg class="u-icon" role="img" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+                                    <path d="M17.6 4.1c.8-.5 1.5-1.4 1.8-2.4-.8.5-1.7.9-2.6 1-.7-.8-1.8-1.4-3-1.4-2.3 0-4.1 1.9-4.1 4.3 0 .3 0 .7.1 1-3.4 0-6.4-1.8-8.4-4.4C1 2.9.8 3.6.8 4.4c0 1.5.7 2.8 1.8 3.6C2 8 1.4 7.8.8 7.5v.1c0 2.1 1.4 3.8 3.3 4.2-.3.1-.7.2-1.1.2-.3 0-.5 0-.8-.1.5 1.7 2 3 3.8 3-1.3 1.1-3.1 1.8-5 1.8-.3 0-.7 0-1-.1 1.8 1.2 4 1.9 6.3 1.9C13.8 18.6 18 12 18 6.3v-.6c.8-.6 1.5-1.4 2-2.2-.7.3-1.5.5-2.4.6z"/>
+                                 </svg>
+                                 \n
+                              </a>
+                              \n
+                           </li>
+                           \n
+                           <li class="c-menu__item">
+                              \n
+                              <a class="c-menu__link" href="https://www.youtube.com/channel/UCvCLdSgYdSTpWcOgEJgi-ng" aria-label="YouTube" data-track="click" data-track-action="youtube" data-track-label="link">
+                                 \n
+                                 <svg class="u-icon" role="img" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+                                    <path d="M7.9 12.6V6.9l5.4 2.8c0 .1-5.4 2.9-5.4 2.9zM19.8 6s-.2-1.4-.8-2c-.8-.8-1.6-.8-2-.9-2.8-.2-7-.2-7-.2s-4.2 0-7 .2c-.4 0-1.2 0-2 .9-.6.6-.8 2-.8 2S0 7.6 0 9.2v1.5c0 1.7.2 3.3.2 3.3s.2 1.4.8 2c.8.8 1.8.8 2.2.9 1.6.1 6.8.2 6.8.2s4.2 0 7-.2c.4 0 1.2-.1 2-.9.6-.6.8-2 .8-2s.2-1.6.2-3.3V9.2c0-1.6-.2-3.2-.2-3.2z"/>
+                                 </svg>
+                                 \n
+                              </a>
+                              \n
+                           </li>
+                           \n
+                        </ul>
+                        \n
+                     </div>
+                     \n\n
+                     <div class="c-footer__grid">
+                        \n
+                        <div class="c-footer__group">
+                           \n
+                           <h3 class="c-footer__heading">Discover content</h3>
+                           \n
+                           <ul class="c-footer__list">
+                              \n
+                              <li class="c-footer__item"><a href="https://www.nature.com/siteindex" data-track="click" data-track-action="journals a-z" data-track-label="link">Journals A-Z</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://www.nature.com/subjects/" data-track="click" data-track-action="article by subject" data-track-label="link">Articles by subject</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://nano.nature.com/" data-track="click" data-track-action="nano" data-track-label="link">Nano</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://www.nature.com/protocolexchange/" data-track="click" data-track-action="protocol exchange" data-track-label="link">Protocol Exchange</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://www.natureindex.com/" data-track="click" data-track-action="nature index" data-track-label="link">Nature Index</a></li>
+                              \n
+                           </ul>
+                           \n
+                        </div>
+                        \n\n
+                        <div class="c-footer__group">
+                           \n
+                           <h3 class="c-footer__heading">Publishing policies</h3>
+                           \n
+                           <ul class="c-footer__list">
+                              \n
+                              <li class="c-footer__item"><a href="https://www.nature.com/authors/editorial_policies/" data-track="click" data-track-action="Nature portfolio policies" data-track-label="link">Nature portfolio policies</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://www.nature.com/nature-research/open-access" data-track="click" data-track-action="open access" data-track-label="link">Open access</a></li>
+                              \n
+                           </ul>
+                           \n
+                        </div>
+                        \n\n
+                        <div class="c-footer__group">
+                           \n
+                           <h3 class="c-footer__heading">Author &amp; Researcher services</h3>
+                           \n
+                           <ul class="c-footer__list">
+                              \n
+                              <li class="c-footer__item"><a href="https://www.nature.com/reprints/" data-track="click" data-track-action="reprints and permissions" data-track-label="link">Reprints &amp; permissions</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://www.springernature.com/gp/authors/research-data" data-track="click" data-track-action="data research service" data-track-label="link">Research data</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://authorservices.springernature.com/go/nr" data-track="click" data-track-action="language editing" data-track-label="link">Language editing</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://authorservices.springernature.com/scientific-editing/" data-track="click" data-track-action="scientific editing" data-track-label="link">Scientific editing</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://masterclasses.nature.com/" data-track="click" data-track-action="nature masterclasses" data-track-label="link">Nature Masterclasses</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://partnerships.nature.com/product/researcher-training/" data-track="click" data-track-action="nature research academies" data-track-label="link">Nature Research Academies</a></li>
+                              \n
+                           </ul>
+                           \n
+                        </div>
+                        \n\n
+                        <div class="c-footer__group">
+                           \n
+                           <h3 class="c-footer__heading">Libraries &amp; institutions</h3>
+                           \n
+                           <ul class="c-footer__list">
+                              \n
+                              <li class="c-footer__item"><a href="https://www.springernature.com/gp/librarians/tools-services" data-track="click" data-track-action="librarian service and tools" data-track-label="link">Librarian service &amp; tools</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://www.springernature.com/gp/librarians/manage-your-account/librarianportal" data-track="click" data-track-action="librarian portal" data-track-label="link">Librarian portal</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://www.nature.com/openresearch/about-open-access/information-for-institutions/" data-track="click" data-track-action="open research" data-track-label="link">Open research</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://www.springernature.com/gp/librarians/recommend-to-your-library" data-track="click" data-track-action="Recommend to library" data-track-label="link">Recommend to library</a></li>
+                              \n
+                           </ul>
+                           \n
+                        </div>
+                        \n\n
+                        <div class="c-footer__group">
+                           \n
+                           <h3 class="c-footer__heading">Advertising &amp; partnerships</h3>
+                           \n
+                           <ul class="c-footer__list">
+                              \n
+                              <li class="c-footer__item"><a href="https://partnerships.nature.com/product/digital-advertising/" data-track="click" data-track-action="advertising" data-track-label="link">Advertising</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://partnerships.nature.com/" data-track="click" data-track-action="partnerships and services" data-track-label="link">Partnerships &amp; Services</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://partnerships.nature.com/media-kits/" data-track="click" data-track-action="media kits" data-track-label="link">Media kits</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://partnerships.nature.com/product/branded-content-native-advertising/" data-track-action="branded content" data-track-label="link">Branded content</a></li>
+                              \n
+                           </ul>
+                           \n
+                        </div>
+                        \n\n
+                        <div class="c-footer__group">
+                           \n
+                           <h3 class="c-footer__heading">Career development</h3>
+                           \n
+                           <ul class="c-footer__list">
+                              \n
+                              <li class="c-footer__item"><a href="https://www.nature.com/naturecareers" data-track="click" data-track-action="nature careers" data-track-label="link">Nature Careers</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://conferences.nature.com" data-track="click" data-track-action="nature conferences" data-track-label="link">Nature<span class="u-visually-hidden"> </span> Conferences</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://www.nature.com/natureevents/" data-track="click" data-track-action="nature events" data-track-label="link">Nature<span class="u-visually-hidden"> </span> events</a></li>
+                              \n
+                           </ul>
+                           \n
+                        </div>
+                        \n\n
+                        <div class="c-footer__group">
+                           \n
+                           <h3 class="c-footer__heading">Regional websites</h3>
+                           \n
+                           <ul class="c-footer__list">
+                              \n
+                              <li class="c-footer__item"><a href="https://www.nature.com/natafrica" data-track="click" data-track-action="nature africa" data-track-label="link">Nature Africa</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="http://www.naturechina.com" data-track="click" data-track-action="nature china" data-track-label="link">Nature China</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://www.nature.com/nindia" data-track="click" data-track-action="nature india" data-track-label="link">Nature India</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://www.nature.com/natitaly" data-track="click" data-track-action="nature Italy" data-track-label="link">Nature Italy</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://www.natureasia.com/ja-jp/" data-track="click" data-track-action="nature japan" data-track-label="link">Nature Japan</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://www.natureasia.com/ko-kr/" data-track="click" data-track-action="nature korea" data-track-label="link">Nature Korea</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://www.nature.com/nmiddleeast/" data-track="click" data-track-action="nature middle east" data-track-label="link">Nature Middle East</a></li>
+                              \n
+                           </ul>
+                           \n
+                        </div>
+                        \n\n
+                        <div class="c-footer__group">
+                           \n
+                           <h3 class="c-footer__heading">Legal &amp; Privacy</h3>
+                           \n
+                           <ul class="c-footer__list">
+                              \n
+                              <li class="c-footer__item"><a href="https://www.nature.com/info/privacy" data-track="click" data-track-action="privacy policy" data-track-label="link">Privacy Policy</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://www.nature.com/info/cookies" data-track="click" data-track-action="use of cookies" data-track-label="link">Use of cookies</a></li>
+                              \n
+                              <li class="c-footer__item"><a class="optanon-toggle-display" href="javascript:;" data-track="click" data-track-action="manage cookies" data-track-label="link">Manage cookies/Do not sell my data</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://www.nature.com/info/legal-notice" data-track="click" data-track-action="legal notice" data-track-label="link">Legal notice</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://www.nature.com/info/accessibility-statement" data-track="click" data-track-action="accessibility statement" data-track-label="link">Accessibility statement</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://www.nature.com/info/terms-and-conditions" data-track="click" data-track-action="terms and conditions" data-track-label="link">Terms &amp; Conditions</a></li>
+                              \n
+                              <li class="c-footer__item"><a href="https://www.springernature.com/ccpa" data-track="click" data-track-action="california privacy statement" data-track-label="link">California Privacy Statement</a></li>
+                              \n
+                           </ul>
+                           \n
+                        </div>
+                        \n
+                     </div>
+                     \n
+                  </div>
+                  \n\n\n
+               </div>
+               \n
+            </div>
+            \n
+         </div>
+         \n\n
+         <div class="c-corporate-footer">
+            \n
+            <div class="u-container">
+               \n        <img src="/static/images/logos/sn-logo-white.ea63208b81.svg" alt="Springer Nature" loading="lazy" width="140" height="14"/>\n
+               <p class="c-corporate-footer__legal" data-test="copyright">&copy; 2021 Springer Nature Limited</p>
+               \n
+            </div>
+            \n
+         </div>
+         \n\n    \n
+         <svg class="u-hide hide">
+            \n
+            <symbol id="global-icon-chevron-right" viewBox="0 0 16 16">
+               \n
+               <path d="M7.782 7L5.3 4.518c-.393-.392-.4-1.022-.02-1.403a1.001 1.001 0 011.417 0l4.176 4.177a1.001 1.001 0 010 1.416l-4.176 4.177a.991.991 0 01-1.4.016 1 1 0 01.003-1.42L7.782 9l1.013-.998z" fill-rule="evenodd"/>
+               \n
+            </symbol>
+            \n
+            <symbol id="global-icon-download" viewBox="0 0 16 16">
+               \n
+               <path d="M2 14c0-.556.449-1 1.002-1h9.996a.999.999 0 110 2H3.002A1.006 1.006 0 012 14zM9 2v6.8l2.482-2.482c.392-.392 1.022-.4 1.403-.02a1.001 1.001 0 010 1.417l-4.177 4.177a1.001 1.001 0 01-1.416 0L3.115 7.715a.991.991 0 01-.016-1.4 1 1 0 011.42.003L7 8.8V2c0-.55.444-.996 1-.996.552 0 1 .445 1 .996z" fill-rule="evenodd"/>
+               \n
+            </symbol>
+            \n
+            <symbol id="global-icon-email" viewBox="0 0 18 18">
+               \n
+               <path d="M1.995 2h14.01A2 2 0 0118 4.006v9.988A2 2 0 0116.005 16H1.995A2 2 0 010 13.994V4.006A2 2 0 011.995 2zM1 13.994A1 1 0 001.995 15h14.01A1 1 0 0017 13.994V4.006A1 1 0 0016.005 3H1.995A1 1 0 001 4.006zM9 11L2 7V5.557l7 4 7-4V7z" fill-rule="evenodd"/>
+               \n
+            </symbol>
+            \n
+            <symbol id="global-icon-institution" viewBox="0 0 18 18">
+               \n
+               <path d="M14 8a1 1 0 011 1v6h1.5a.5.5 0 01.5.5v.5h.5a.5.5 0 01.5.5V18H0v-1.5a.5.5 0 01.5-.5H1v-.5a.5.5 0 01.5-.5H3V9a1 1 0 112 0v6h8V9a1 1 0 011-1zM6 8l2 1v4l-2 1zm6 0v6l-2-1V9zM9.573.401l7.036 4.925A.92.92 0 0116.081 7H1.92a.92.92 0 01-.528-1.674L8.427.401a1 1 0 011.146 0zM9 2.441L5.345 5h7.31z" fill-rule="evenodd"/>
+               \n
+            </symbol>
+            \n
+            <symbol id="global-icon-search" viewBox="0 0 22 22">
+               \n
+               <path fill-rule="evenodd" d="M21.697 20.261a1.028 1.028 0 01.01 1.448 1.034 1.034 0 01-1.448-.01l-4.267-4.267A9.812 9.811 0 010 9.812a9.812 9.811 0 1117.43 6.182zM9.812 18.222A8.41 8.41 0 109.81 1.403a8.41 8.41 0 000 16.82z"/>
+               \n
+            </symbol>
+            \n
+            <symbol id="icon-info" viewBox="0 0 18 18">
+               \n
+               <path d="m9 0c4.9705627 0 9 4.02943725 9 9 0 4.9705627-4.0294373 9-9 9-4.97056275 0-9-4.0294373-9-9 0-4.97056275 4.02943725-9 9-9zm0 7h-1.5l-.11662113.00672773c-.49733868.05776511-.88337887.48043643-.88337887.99327227 0 .47338693.32893365.86994729.77070917.97358929l.1126697.01968298.11662113.00672773h.5v3h-.5l-.11662113.0067277c-.42082504.0488782-.76196299.3590206-.85696816.7639815l-.01968298.1126697-.00672773.1166211.00672773.1166211c.04887817.4208251.35902055.761963.76398144.8569682l.1126697.019683.11662113.0067277h3l.1166211-.0067277c.4973387-.0577651.8833789-.4804365.8833789-.9932723 0-.4733869-.3289337-.8699473-.7707092-.9735893l-.1126697-.019683-.1166211-.0067277h-.5v-4l-.00672773-.11662113c-.04887817-.42082504-.35902055-.76196299-.76398144-.85696816l-.1126697-.01968298zm0-3.25c-.69035594 0-1.25.55964406-1.25 1.25s.55964406 1.25 1.25 1.25 1.25-.55964406 1.25-1.25-.55964406-1.25-1.25-1.25z" fill-rule="evenodd"/>
+               \n
+            </symbol>
+            \n
+            <symbol id="icon-success" viewBox="0 0 18 18">
+               \n
+               <path d="M9 0a9 9 0 110 18A9 9 0 019 0zm3.486 4.982l-4.718 5.506L5.14 8.465a.991.991 0 00-1.423.133 1.06 1.06 0 00.13 1.463l3.407 2.733a1 1 0 001.387-.133l5.385-6.334a1.06 1.06 0 00-.116-1.464.991.991 0 00-1.424.119z" fill-rule="evenodd"/>
+               \n
+            </symbol>
+            \n
+            <symbol id="icon-chevron-down" viewBox="0 0 16 16">
+               \n
+               <path d="m5.58578644 3-3.29289322-3.29289322c-.39052429-.39052429-.39052429-1.02368927 0-1.41421356s1.02368927-.39052429 1.41421356 0l4 4c.39052429.39052429.39052429 1.02368927 0 1.41421356l-4 4c-.39052429.39052429-1.02368927.39052429-1.41421356 0s-.39052429-1.02368927 0-1.41421356z" fill-rule="evenodd" transform="matrix(0 1 -1 0 11 1)"/>
+               \n
+            </symbol>
+            \n
+         </svg>
+         \n\n
+      </footer>
+      \n\n\n\n\n    \n        \n\n<div class="c-site-messages message hide u-hide-print c-site-messages--nature-briefing c-site-messages--nature-briefing-email-variant c-site-messages--nature-briefing-redesign-2020 sans-serif"\ndata-component-id="nature-briefing-banner"\ndata-component-expirydays="30"\ndata-component-trigger-scroll-percentage="15"\ndata-track="in-view"\ndata-track-action="in-view"\ndata-track-category="nature briefing"\ndata-track-label="redesign banner visible">\n\n    \n
+      <div class="c-site-messages__banner-large">
+         \n\n        \n
+         <div class="c-site-messages__close-container">
+            \n    <button class="c-site-messages__close"\n        data-track="click"\n        data-track-category="nature briefing"\n        data-track-label="redesign banner dismiss">\n        <?xml version="1.0" encoding="UTF-8" standalone="no"?>\n
+            <svg width="25px" height="25px" focusable="false" aria-hidden="true" viewBox="0 0 25 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+               \n
+               <title>Close banner</title>
+               \n
+               <defs></defs>
+               \n
+               <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                  \n
+                  <rect opacity="0" x="0" y="0" width="25" height="25"></rect>
+                  \n
+                  <path d="M6.29679575,16.2772478 C5.90020818,16.6738354 5.90240728,17.3100587 6.29617427,17.7038257 C6.69268654,18.100338 7.32864195,18.0973145 7.72275218,17.7032043 L12,13.4259564 L16.2772478,17.7032043 C16.6738354,18.0997918 17.3100587,18.0975927 17.7038257,17.7038257 C18.100338,17.3073135 18.0973145,16.671358 17.7032043,16.2772478 L13.4259564,12 L17.7032043,7.72275218 C18.0997918,7.32616461 18.0975927,6.68994127 17.7038257,6.29617427 C17.3073135,5.89966201 16.671358,5.90268552 16.2772478,6.29679575 L12,10.5740436 L7.72275218,6.29679575 C7.32616461,5.90020818 6.68994127,5.90240728 6.29617427,6.29617427 C5.89966201,6.69268654 5.90268552,7.32864195 6.29679575,7.72275218 L10.5740436,12 L6.29679575,16.2772478 Z" fill="#ffffff"></path>
+                  \n
+               </g>
+               \n
+            </svg>
+            \n        <span class="visually-hidden">Close</span>\n    </button>\n
+         </div>
+         \n\n\n
+         <div class="c-site-messages__form-container">
+            \n\n
+            <div class="grid grid-12 last">
+               \n
+               <div class="grid grid-4">
+                  \n                    <img alt="Nature Briefing" src="/static/images/logos/nature-briefing-logo-n150-white.d81c9da3ec.svg" width="250" height="40">\n
+                  <p class="c-site-messages--nature-briefing__strapline extra-tight-line-height">Sign up for the <em>Nature Briefing</em> newsletter — what matters in science, free to your inbox daily.</p>
+                  \n
+               </div>
+               \n
+               <div class="grid grid-8 last">
+                  \n
+                  <form action="/briefing/signup/formfeedback" method="post" data-location="banner" data-track="submit" data-track-action="transmit-form">
+                     \n                        <input id="briefing-banner-signup-form-input-track-originReferralPoint" type="hidden" name="track_originReferralPoint" value="DirectEmailBannerRedesign2020">\n                        <input id="briefing-banner-signup-form-input-track-formType" type="hidden" name="track_formType" value="DirectEmailBanner">\n                        <label class="nature-briefing-banner__email-label" for="banner-EmailAddressInput">Email address</label>\n\n
+                     <div class="nature-briefing-banner__email-wrapper">\n                            <input class="nature-briefing-banner__email-input box-sizing text14" type="email" id="banner-EmailAddressInput" name="email" value="" placeholder="e.g. jo.smith@university.ac.uk" required="true" aria-required="true" data-test-element="briefing-emailbanner-email-input">\n                            <button type="submit" class="nature-briefing-banner__submit-button box-sizing text14" data-test-element="briefing-emailbanner-signup-button">Sign up</button>\n                        </div>
+                     \n\n
+                     <div class="nature-briefing-banner__checkbox-wrapper grid grid-12 last">\n                            <input class="nature-briefing-banner__checkbox-checkbox" id="gdpr-briefing-banner-checkbox" type="checkbox" name="gdpr" value="1" data-test-element="briefing-emailbanner-gdpr-checkbox" required>\n                            <label class="nature-briefing-banner__checkbox-label box-sizing text13 sans-serif block tighten-line-height" for="gdpr-briefing-banner-checkbox">I agree my information will be processed in accordance with the <em>Nature</em> and Springer Nature Limited <a href="https://www.nature.com/info/privacy">Privacy Policy</a>.</label>\n                        </div>
+                     \n
+                  </form>
+                  \n
+               </div>
+               \n
+            </div>
+            \n\n
+         </div>
+         \n\n
+      </div>
+      \n\n    \n
+      <div class="c-site-messages__banner-small">
+         \n\n        \n
+         <div class="c-site-messages__close-container">
+            \n    <button class="c-site-messages__close"\n        data-track="click"\n        data-track-category="nature briefing"\n        data-track-label="redesign banner dismiss">\n        <?xml version="1.0" encoding="UTF-8" standalone="no"?>\n
+            <svg width="25px" height="25px" focusable="false" aria-hidden="true" viewBox="0 0 25 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+               \n
+               <title>Close banner</title>
+               \n
+               <defs></defs>
+               \n
+               <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                  \n
+                  <rect opacity="0" x="0" y="0" width="25" height="25"></rect>
+                  \n
+                  <path d="M6.29679575,16.2772478 C5.90020818,16.6738354 5.90240728,17.3100587 6.29617427,17.7038257 C6.69268654,18.100338 7.32864195,18.0973145 7.72275218,17.7032043 L12,13.4259564 L16.2772478,17.7032043 C16.6738354,18.0997918 17.3100587,18.0975927 17.7038257,17.7038257 C18.100338,17.3073135 18.0973145,16.671358 17.7032043,16.2772478 L13.4259564,12 L17.7032043,7.72275218 C18.0997918,7.32616461 18.0975927,6.68994127 17.7038257,6.29617427 C17.3073135,5.89966201 16.671358,5.90268552 16.2772478,6.29679575 L12,10.5740436 L7.72275218,6.29679575 C7.32616461,5.90020818 6.68994127,5.90240728 6.29617427,6.29617427 C5.89966201,6.69268654 5.90268552,7.32864195 6.29679575,7.72275218 L10.5740436,12 L6.29679575,16.2772478 Z" fill="#ffffff"></path>
+                  \n
+               </g>
+               \n
+            </svg>
+            \n        <span class="visually-hidden">Close</span>\n    </button>\n
+         </div>
+         \n\n\n
+         <div class="c-site-messages__content text14">\n            <span class="c-site-messages--nature-briefing__strapline strong">Get the most important science stories of the day, free in your inbox.</span>\n            <a class="nature-briefing__link text14 sans-serif"\n                data-track="click"\n                data-track-category="nature briefing"\n                data-track-label="redesign banner CTA to site"\n                data-test-element="briefing-banner-link"\n                target="_blank"\n                rel="noreferrer noopener"\n                href="/briefing/signup/?origin=Nature&amp;originReferralPoint=EmailBanner">Sign up for Nature Briefing\n            </a>\n        </div>
+         \n\n
+      </div>
+      \n\n</div>\n    \n\n\n\n\n
+      <noscript>\n    <img hidden src="https://verify.nature.com/verify/nature.png" border="0" width="0" height="0" style="display: none" alt="">\n</noscript>
+      \n\n\n\n\n<script src="//content.readcube.com/ping?doi=10.1038/s41467-021-25914-8&amp;format=js&amp;last_modified=2021-10-13" async></script>\n<img src="/platform/track/article/s41467-021-25914-8" width="1" height="1" alt="" class="u-visually-hidden"/>\n
+   </body>
+   \n
+</html>
+\n

--- a/tests/test_article_only.py
+++ b/tests/test_article_only.py
@@ -124,3 +124,14 @@ class TestArticleOnly(unittest.TestCase):
         sample = load_sample("utf-8-kanji.sample.html")
         doc = Document(sample)
         res = doc.summary()
+
+    def test_nature(self):
+        """Using the si sample, make sure we can get the article alone."""
+        sample = load_sample("nature.html")
+        doc = Document(sample, url="https://www.nature.com/articles/s41467-021-25914-8")
+        res = doc.summary()
+
+        abstract_first_sentence = "There is conflicting evidence"
+        introduction_first_sentence = "Severe acute respiratory syndrome coronavirus 2"
+        self.assertIn(abstract_first_sentence, res)
+        self.assertIn(introduction_first_sentence, res)


### PR DESCRIPTION
We just extract a blurb for the nature article, while the full content is available in the resp.

https://www.nature.com/articles/s41467-021-25914-8

Readability extracted content:

```
Comments
By submitting a comment you agree to abide by our Terms and Community Guidelines. If you find something abusive or that does not comply with our terms or guidelines please flag it as inappropriate.
```

On the other hand, it seems that python-readability only extracts the References section.

Feedly article:
[A cross-sectional analysis of meteorological factors and SARS-CoV-2 transmission in 409 cities across 26 countries](https://feedly.com/i/entry/NBD+i6c008s5kZQwRdSBZkXXz/7slN5dGX7oJw/jYAE=_17c790a1567:2476a8d:edff7ee2)